### PR TITLE
Requote BigQuery columns

### DIFF
--- a/dbcrossbar/fixtures/exact_output.csv
+++ b/dbcrossbar/fixtures/exact_output.csv
@@ -1,4 +1,4 @@
-id,test_bool,test_date,test_int16,test_int32,test_int64,test_text,test_timestamp_without_time_zone,test_timestamp_with_time_zone,test_uuid,testCapitalized
-1,t,1969-07-20,-32768,-2147483648,-9223372036854775808,hello,1969-07-20T20:17:39,1969-07-20T20:17:39Z,084ec3bb-3193-4ffb-8b74-99a288e8432c,
-2,f,2001-01-01,32767,2147483647,9223372036854775807,,,,,
-3,,,,,,,,,,
+id,test_bool,test_date,test_int16,test_int32,test_int64,test_text,test_timestamp_without_time_zone,test_timestamp_with_time_zone,test_uuid,select,testCapitalized
+1,t,1969-07-20,-32768,-2147483648,-9223372036854775808,hello,1969-07-20T20:17:39,1969-07-20T20:17:39Z,084ec3bb-3193-4ffb-8b74-99a288e8432c,,
+2,f,2001-01-01,32767,2147483647,9223372036854775807,,,,,,
+3,,,,,,,,,,,

--- a/dbcrossbar/fixtures/exact_output.sql
+++ b/dbcrossbar/fixtures/exact_output.sql
@@ -9,5 +9,6 @@ CREATE TABLE exact_output (
     test_timestamp_without_time_zone timestamp,
     test_timestamp_with_time_zone timestamp with time zone,
     test_uuid uuid,
+    "select" text,
     testCapitalized text
 );

--- a/dbcrossbar/fixtures/upsert.sql
+++ b/dbcrossbar/fixtures/upsert.sql
@@ -3,6 +3,7 @@ CREATE TABLE upsert_test (
     key2 INT NOT NULL,
     value TEXT,
     more TEXT[],
+    "select" TEXT,
     camelCase TEXT
 );
 

--- a/dbcrossbar/fixtures/upsert_1.csv
+++ b/dbcrossbar/fixtures/upsert_1.csv
@@ -1,3 +1,3 @@
-key1,key2,value,more,camelCase
-1,1,a,"[""x"",""y""]",
-1,2,b,"[""x"",""y""]",
+key1,key2,value,more,select,camelCase
+1,1,a,"[""x"",""y""]",,
+1,2,b,"[""x"",""y""]",,

--- a/dbcrossbar/fixtures/upsert_2.csv
+++ b/dbcrossbar/fixtures/upsert_2.csv
@@ -1,3 +1,3 @@
-key1,key2,value,more,camelCase
-1,2,c,"[""x""]",
-1,3,d,"[""x"",""y""]",
+key1,key2,value,more,select,camelCase
+1,2,c,"[""x""]",,
+1,3,d,"[""x"",""y""]",,

--- a/dbcrossbar/fixtures/upsert_result.csv
+++ b/dbcrossbar/fixtures/upsert_result.csv
@@ -1,4 +1,4 @@
-key1,key2,value,more,camelCase
-1,1,a,"[""x"",""y""]",
-1,2,c,"[""x""]",
-1,3,d,"[""x"",""y""]",
+key1,key2,value,more,select,camelCase
+1,1,a,"[""x"",""y""]",,
+1,2,c,"[""x""]",,
+1,3,d,"[""x"",""y""]",,

--- a/dbcrossbar/tests/cli/cp/bigquery.rs
+++ b/dbcrossbar/tests/cli/cp/bigquery.rs
@@ -182,7 +182,7 @@ fn bigquery_upsert() {
     let bq_table = bq_test_table("bigquery_upsert");
 
     // CSVes to BigQuery.
-    let mut first = false;
+    let mut first = true;
     for src in srcs {
         let if_exists = if first {
             first = false;

--- a/dbcrossbarlib/src/drivers/bigquery_shared/data_type.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/data_type.rs
@@ -437,7 +437,7 @@ impl fmt::Display for BqStructField {
         if let Some(name) = &self.name {
             // TODO: It's not clear whether we can/should escape this using
             // `Ident` to insert backticks.
-            write!(f, "{} ", name)?;
+            write!(f, "{} ", name.quoted())?;
         }
         write!(f, "{}", self.ty)
     }

--- a/dbcrossbarlib/src/drivers/bigquery_shared/table.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/table.rs
@@ -127,7 +127,7 @@ impl BqTable {
                     } else {
                         Err(format_err!(
                             "could not find column {} in BigQuery table {}",
-                            c.name,
+                            c.name.quoted(),
                             self.name,
                         ))
                     }
@@ -215,7 +215,7 @@ impl BqTable {
             if i > 0 {
                 writeln!(f, ",")?;
             }
-            write!(f, "    {} {}", col.name, col.bq_data_type()?)?;
+            write!(f, "    {} {}", col.name.quoted(), col.bq_data_type()?)?;
             if col.is_not_null() {
                 write!(f, " NOT NULL")?;
             }
@@ -240,7 +240,7 @@ impl BqTable {
             f,
             "INSERT INTO {} ({})",
             self.name.dotted_and_quoted(),
-            self.columns.iter().map(|c| &c.name).join(","),
+            self.columns.iter().map(|c| c.name.quoted()).join(","),
         )?;
         write!(f, "SELECT ")?;
         for (i, col) in self.columns.iter().enumerate() {
@@ -320,7 +320,7 @@ WHEN NOT MATCHED THEN INSERT (
                 .enumerate()
                 .map(|(idx, c)| format!(
                     "dest.{col} = {expr}",
-                    col = c.name,
+                    col = c.name.quoted(),
                     expr = col_import_expr(c, idx),
                 ))
                 .join(" AND\n    "),
@@ -333,12 +333,12 @@ WHEN NOT MATCHED THEN INSERT (
                 } else {
                     Some(format!(
                         "{col} = {expr}",
-                        col = c.name,
+                        col = c.name.quoted(),
                         expr = col_import_expr(c, idx),
                     ))
                 })
                 .join(",\n    "),
-            columns = self.columns.iter().map(|c| &c.name).join(",\n    "),
+            columns = self.columns.iter().map(|c| c.name.quoted()).join(",\n    "),
             values = self
                 .columns
                 .iter()


### PR DESCRIPTION
We removed quoting on BigQuery column in 0.3.0, because we knew they
were well-behaved identifiers. But I forgot about names like "group" and
"select".

This patch prints BigQuery column names in quoted format again.