### PR TITLE
Google Cloud Storage fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,6 +474,7 @@ dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "geo-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "geojson 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "headers 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -816,6 +817,29 @@ dependencies = [
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "headers"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "headers-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha-1 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2541,6 +2565,8 @@ dependencies = [
 "checksum geojson 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c2b6970b36b77807a4ea232fcbc13b29026eab7c7e906500446c1e03d16f43af"
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 "checksum h2 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "377038bf3c89d18d6ca1431e7a5027194fbd724ca10592b9487ede5e8e144f42"
+"checksum headers 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ed18eb2459bf1a09ad2d6b1547840c3e5e62882fa09b9a6a20b1de8e3228848f"
+"checksum headers-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hermit-abi 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "725cf19794cf90aa94e65050cb4191ff5d8fa87a498383774c47b332e3af952e"
 "checksum hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"

--- a/README.md
+++ b/README.md
@@ -99,4 +99,4 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 
 ### Third-party libraries
 
-`dbcrossbar` depends on a variety of third-party libraries, each with their own copyright and license. We have configured a [`deny.toml` file](./deny.toml) that currently attempts to restrict our dependencies to MIT, Apache-2.0, BSD-3-Clause, BSD-2-Clause, CC0-1.0 and ISC licenses, with a single MPL-2.0 dependency. But please verify the `deny.toml` file (and individual dependencies) to be certain, because details may change in the future. Each of these licenses imposes certain obligations on redistribution.
+`dbcrossbar` depends on a variety of third-party libraries, each with their own copyright and license. We have configured a [`deny.toml` file](./deny.toml) that currently attempts to restrict our dependencies to MIT, Apache-2.0, BSD-3-Clause, BSD-2-Clause, CC0-1.0, ISC and OpenSSL licenses, with a single MPL-2.0 dependency. But please verify the `deny.toml` file (and individual dependencies) to be certain, because details may change in the future. Each of these licenses imposes certain obligations on redistribution.

--- a/dbcrossbarlib/Cargo.toml
+++ b/dbcrossbarlib/Cargo.toml
@@ -35,6 +35,7 @@ failure = "0.1.2"
 futures = "0.3.1"
 geo-types = "0.5"
 geojson = { version = "0.18.0", features = ["geo-types"] }
+headers = "0.3.2"
 hex = "0.4.0"
 hmac = "0.7.1"
 hyper = "0.13.4"

--- a/dbcrossbarlib/src/clouds/gcloud/storage/download_file.rs
+++ b/dbcrossbarlib/src/clouds/gcloud/storage/download_file.rs
@@ -1,27 +1,176 @@
 //! Download a file from Google Cloud storage.
 
+use bytes::BufMut;
+use futures::stream;
+use headers::{ContentRange, Header, HeaderMapExt, Range};
+use reqwest::header::{HeaderMap, HeaderValue, IF_MATCH};
+use std::{cmp::min, convert::TryFrom, ops};
+use tokio::spawn;
+
 use super::{
     super::{percent_encode, AltQuery, Client},
-    parse_gs_url,
+    parse_gs_url, StorageObject, CHUNK_SIZE,
 };
 use crate::common::*;
-use crate::tokio_glue::http_response_stream;
+
+/// Maximum number of parallel downloads.
+const PARALLEL_DOWNLOADS: usize = 5;
 
 /// Download the file at the specified URL as a stream.
 pub(crate) async fn download_file(
     ctx: &Context,
-    file_url: &Url,
+    item: &StorageObject,
 ) -> Result<BoxStream<BytesMut>> {
+    let file_url = item.to_url_string().parse::<Url>()?;
     debug!(ctx.log(), "streaming from {}", file_url);
-    let (bucket, object) = parse_gs_url(file_url)?;
+    let (bucket, object) = parse_gs_url(&file_url)?;
 
-    // Make our request.
+    // Build our URL & common headers.
     let url = format!(
         "https://storage.googleapis.com/storage/v1/b/{}/o/{}",
         percent_encode(&bucket),
         percent_encode(&object),
     );
-    let client = Client::new(ctx).await?;
-    let resp = client.get_response(ctx, &url, AltQuery::media()).await?;
-    Ok(http_response_stream(resp))
+    let mut common_headers = HeaderMap::default();
+    common_headers.insert(IF_MATCH, HeaderValue::from_str(&item.etag)?);
+
+    // Build a stream of download tasks.
+    let ctx = ctx.to_owned();
+    let stream = stream::iter(chunk_ranges(CHUNK_SIZE, item.size()?))
+        .map(move |range| {
+            download_range(ctx.clone(), url.clone(), common_headers.clone(), range)
+                .boxed()
+        })
+        // Use `tokio` magic to download up to `PARALLEL_DOWNLOADS` chunks in parallel.
+        .buffered(PARALLEL_DOWNLOADS)
+        .boxed();
+
+    Ok(stream)
+}
+
+/// Download a single range of the file.
+///
+/// Unlike typical Rust futures *will not block the download*, even if you don't
+/// poll it. This runs the download in a separate `tokio` task. We do this to avoid
+/// downloads that get stalled halfway through by backpressure.
+async fn download_range(
+    ctx: Context,
+    url: String,
+    mut headers: HeaderMap,
+    range: ops::Range<u64>,
+) -> Result<BytesMut> {
+    trace!(
+        ctx.log(),
+        "downloading {} bytes {}-{}",
+        url,
+        range.start,
+        range.end,
+    );
+
+    // Do our work in a separately spawned task to avoid blocking during
+    // backpressure. This is reasonable because we're downloading a chunk of
+    // predictable size.
+    let task_fut = async move {
+        // Make our request.
+        let client = Client::new(&ctx).await?;
+        headers.typed_insert(Range::bytes(range.clone())?);
+        let response = client
+            .get_response(&ctx, &url, AltQuery::media(), headers)
+            .await?;
+
+        // Make sure we're downloading the range we expect.
+        let content_range = get_header::<ContentRange>(&response)?;
+        let (start, end_inclusive) = content_range
+            .bytes_range()
+            .ok_or_else(|| format_err!("could not get range from Content-Range"))?;
+        if start != range.start || end_inclusive + 1 != range.end {
+            return Err(format_err!(
+                "expected to download range [{}, {}), but server offered [{}, {})",
+                range.start,
+                range.end,
+                start,
+                end_inclusive + 1,
+            ));
+        }
+
+        // Download the data to a buffer.
+        let bytes_to_download = usize::try_from(range.end - range.start)
+            .with_context(|_| {
+                format!("range {:?} is to big to fit in memory", range)
+            })?;
+        let mut buffer = BytesMut::with_capacity(bytes_to_download);
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            buffer.put(chunk?);
+        }
+
+        // Did we download the number of bytes the `Content-Range` header promised?
+        if bytes_to_download == buffer.len() {
+            Ok(buffer)
+        } else {
+            Err(format_err!(
+                "expected to download {} bytes, received {}",
+                bytes_to_download,
+                buffer.len(),
+            ))
+        }
+    };
+    let task = spawn(task_fut);
+    let buffer = task.await.context("error joining background task")??;
+    Ok(buffer)
+}
+
+/// Get a typed header, and return an error if it isn't present.
+fn get_header<H>(response: &reqwest::Response) -> Result<H>
+where
+    H: Header,
+{
+    response
+        .headers()
+        .typed_try_get::<H>()
+        .with_context(|_| format!("error parsing {}", H::name()))?
+        .ok_or_else(|| format_err!("expected {} header", H::name()))
+}
+
+/// An iterator which returns ranges for each chunk in a file.
+#[derive(Debug)]
+struct ChunkRanges {
+    /// The size of chunk we want to return.
+    chunk_size: u64,
+    /// The total length of our file.
+    len: u64,
+    /// The place to start our next range.
+    next_start: u64,
+}
+
+impl Iterator for ChunkRanges {
+    type Item = ops::Range<u64>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.next_start < self.len {
+            let end = min(self.next_start + self.chunk_size, self.len);
+            let range = self.next_start..end;
+            self.next_start = end;
+            Some(range)
+        } else {
+            None
+        }
+    }
+}
+
+/// Return an iterator over successive subranges of a file, each containing
+/// `chunk_size` bytes except the last.
+fn chunk_ranges(chunk_size: u64, len: u64) -> ChunkRanges {
+    assert!(chunk_size > 0);
+    ChunkRanges {
+        chunk_size,
+        len,
+        next_start: 0,
+    }
+}
+
+#[test]
+fn chunk_ranges_returns_sequential_ranges() {
+    let ranges = chunk_ranges(10, 25).collect::<Vec<_>>();
+    assert_eq!(ranges, &[0..10, 10..20, 20..25]);
 }

--- a/dbcrossbarlib/src/clouds/gcloud/storage/mod.rs
+++ b/dbcrossbarlib/src/clouds/gcloud/storage/mod.rs
@@ -1,5 +1,7 @@
 //! Interfaces to Google Cloud Storage.
 
+use serde::Deserialize;
+
 use crate::common::*;
 
 mod download_file;
@@ -12,6 +14,27 @@ pub(crate) use ls::ls;
 pub(crate) use rmdir::rmdir;
 pub(crate) use upload_file::upload_file;
 
+/// Chunk size to use when working with Google Cloud Storage.
+///
+/// This needs to satisfy two constraints:
+///
+/// 1. It needs to be small enough that we can keep, say, 40 chunks in memory
+///    with no problem, if we assume 8 streams and 5 active chunks per stream.
+///    (Plus more for any other driver running at the same time, and for the
+///    pipeline between.)
+/// 2. It needs to be large enough to ensure good performance from the storage
+///    APIs. Google [recommends][opt] 1 MiB minimum chunks.
+///
+/// [opt]: https://cloud.google.com/blog/products/gcp/optimizing-your-cloud-storage-performance-google-cloud-performance-atlas
+#[cfg(not(debug_assertions))]
+pub(crate) const CHUNK_SIZE: u64 = 1024 * 1024;
+
+// Use a much smaller chunk size when testing to force our chunking code to be
+// used. We key off "debug_assertions" because that seems to be the easiest way
+// to test whether we're in release mode.
+#[cfg(debug_assertions)]
+pub(crate) const CHUNK_SIZE: u64 = 128;
+
 /// Split a `gs://` URL into a bucket and an object name.
 pub(crate) fn parse_gs_url(url: &Url) -> Result<(String, String)> {
     if url.scheme() != "gs" {
@@ -23,5 +46,34 @@ pub(crate) fn parse_gs_url(url: &Url) -> Result<(String, String)> {
             .to_owned();
         let object = (&url.path()[1..]).to_owned();
         Ok((bucket, object))
+    }
+}
+
+/// Information about an individual object.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct StorageObject {
+    /// The bucket of this object.
+    pub(crate) bucket: String,
+    /// The name of this object. This typically looks like a path without the leading slash.
+    pub(crate) name: String,
+    /// The etag of this object. This is used to make sure it doesn't change unexpectedly.
+    pub(crate) etag: String,
+    /// The size of this oject, in bytes.
+    pub(crate) size: String,
+}
+
+impl StorageObject {
+    /// Convert this to a `gs://` URL.
+    pub(crate) fn to_url_string(&self) -> String {
+        format!("gs://{}/{}", self.bucket, self.name)
+    }
+
+    /// Parse the `size` field that gets returned as a string.
+    pub(crate) fn size(&self) -> Result<u64> {
+        Ok(self
+            .size
+            .parse::<u64>()
+            .context("could not parse object size")?)
     }
 }

--- a/dbcrossbarlib/src/clouds/gcloud/storage/rmdir.rs
+++ b/dbcrossbarlib/src/clouds/gcloud/storage/rmdir.rs
@@ -25,9 +25,10 @@ pub(crate) async fn rmdir(ctx: &Context, url: &Url) -> Result<()> {
     let url_stream = ls(ctx, url).await?;
     let ctx = ctx.clone();
     let del_fut_stream: BoxStream<BoxFuture<()>> = url_stream
-        .map_ok(move |url| {
+        .map_ok(move |item| {
             let ctx = ctx.clone();
             async move {
+                let url = item.to_url_string();
                 trace!(ctx.log(), "deleting {}", url);
                 let url = url.parse::<Url>()?;
                 let (bucket, object) = parse_gs_url(&url)?;

--- a/dbcrossbarlib/src/drivers/bigquery_shared/table_name.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/table_name.rs
@@ -111,7 +111,7 @@ impl FromStr for TableName {
 
     fn from_str(s: &str) -> Result<Self> {
         lazy_static! {
-            static ref RE: Regex = Regex::new("^([^:.]+):([^:.]+).([^:.]+)$")
+            static ref RE: Regex = Regex::new("^([^:.`]+):([^:.`]+).([^:.`]+)$")
                 .expect("could not parse built-in regex");
         }
         let cap = RE.captures(s).ok_or_else(|| {

--- a/dbcrossbarlib/src/drivers/gs/local_data.rs
+++ b/dbcrossbarlib/src/drivers/gs/local_data.rs
@@ -18,16 +18,16 @@ pub(crate) async fn local_data_helper(
 
     let file_urls = storage::ls(&ctx, &url).await?;
 
-    let csv_streams = file_urls.and_then(move |file_url| {
+    let csv_streams = file_urls.and_then(move |item| {
         let ctx = ctx.clone();
         let url = url.clone();
         async move {
             // Stream the file from the cloud.
+            let file_url = item.to_url_string();
             let name = csv_stream_name(url.as_str(), &file_url)?;
             let ctx =
                 ctx.child(o!("stream" => name.to_owned(), "url" => file_url.clone()));
-            let file_url = Url::parse(&file_url)?;
-            let data = storage::download_file(&ctx, &file_url).await?;
+            let data = storage::download_file(&ctx, &item).await?;
 
             // Assemble everything into a CSV stream.
             Ok(CsvStream {

--- a/deny.toml
+++ b/deny.toml
@@ -9,19 +9,27 @@ unlicensed = "deny"
 # Don't allow "copylefted" licenses unless they're listed below.
 copyleft = "deny"
 
-# Allow common non-restrictive licenses.
-allow = ["MIT", "Apache-2.0", "BSD-3-Clause", "BSD-2-Clause", "CC0-1.0"]
+# Allow common non-restrictive licenses. ISC is used for various DNS and crypto
+# things, and it's a minimally restrictive open source license.
+allow = ["MIT", "Apache-2.0", "BSD-3-Clause", "BSD-2-Clause", "CC0-1.0", "ISC", "OpenSSL"]
 
 # Many organizations ban AGPL-licensed code
 # https://opensource.google/docs/using/agpl-policy/
 deny = ["AGPL-3.0"]
 
-# Some slightly odder licenses. ISC is an unrestrictive license but unusual, and
-# MPL-2.0 is long and complicated "copyleft" license that's less strict than the
-# GPL. 
+# Some slightly odder licenses. MPL-2.0 is a long and complicated "copyleft"
+# license that's less strict than the GPL. 
 exceptions = [
-    { name = "rdrand", allow = ["ISC"] },
     { name = "slog-json", allow = ["MPL-2.0"] },
+]
+
+[[licenses.clarify]]
+# Ring has a messy license. We should either commit 100% to ring everywhere, or
+# to native-tls everywhere, and not mix the two.
+name = "ring"
+expression = "ISC AND OpenSSL AND MIT"
+license-files = [
+    { path = "LICENSE", hash = 3171872035 },
 ]
 
 [bans]
@@ -50,6 +58,9 @@ skip-tree = [
     # introduces duplicate dependencies.
     { name = "slog-term" },
     { name = "slog-envlogger" },
+
+    # This needs updates.
+    { name = "rustls-native-certs" },
 ]
 
 


### PR DESCRIPTION
This PR includes two improvements:

1. A correctness fix to the `ls` code.
2. A major performance and backpressure fix to `download_file` which basically amounts to a rewrite.

We should probably devote some more effort to batching `rm` and to making `upload_file` chunked, too. But this is a very good start.

This leaves only a few items on https://github.com/dbcrossbar/dbcrossbar/issues/112 that are blocking a useful 0.4.0-alpha.1 release.