### PR TITLE
Prepare for v0.4.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "async-trait"
-version = "0.1.27"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -460,6 +460,7 @@ dependencies = [
 name = "dbcrossbarlib"
 version = "0.3.3"
 dependencies = [
+ "async-trait 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bigml 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2140,7 +2141,7 @@ name = "tokio-postgres"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "async-trait 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallible-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2483,7 +2484,7 @@ dependencies = [
 "checksum arc-swap 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d663a8e9a99154b5fb793032533f6328da35e23aac63d5c152279aa8ba356825"
 "checksum arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 "checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
-"checksum async-trait 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)" = "991d0a1a3e790c835fd54ab41742a59251338d8c7577fe7d7f0170c7072be708"
+"checksum async-trait 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)" = "bab5c215748dc1ad11a145359b1067107ae0f8ca5e99844fa64067ed5bf198e3"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 "checksum backtrace 0.3.46 (registry+https://github.com/rust-lang/crates.io-index)" = "b1e692897359247cc6bb902933361652380af0f1b7651ae5c5013407f30e109e"

--- a/dbcrossbarlib/Cargo.toml
+++ b/dbcrossbarlib/Cargo.toml
@@ -21,6 +21,7 @@ slog-envlogger = "2.1.0"
 slog-term = "2.4.0"
 
 [dependencies]
+async-trait = "0.1.29"
 base64 = "0.12.0"
 bigml = "0.6.3"
 byteorder = "1.3.1"

--- a/dbcrossbarlib/src/clouds/gcloud/auth.rs
+++ b/dbcrossbarlib/src/clouds/gcloud/auth.rs
@@ -4,7 +4,7 @@ use dirs;
 use hyper::{self, client::connect::HttpConnector};
 use hyper_rustls::HttpsConnector;
 use serde_json;
-use std::{env, path::PathBuf};
+use std::path::PathBuf;
 pub(crate) use yup_oauth2::AccessToken;
 use yup_oauth2::{
     ApplicationSecret, ConsoleApplicationSecret, InstalledFlowReturnMethod,
@@ -12,6 +12,7 @@ use yup_oauth2::{
 };
 
 use crate::common::*;
+use crate::credentials::CredentialsManager;
 
 /// The connector type used to create `hyper` connections.
 pub(crate) type HyperConnector = HttpsConnector<HttpConnector>;
@@ -29,17 +30,18 @@ fn token_file_path() -> Result<PathBuf> {
 }
 
 /// Get the service account key needed to connect a server app to BigQuery.
-fn service_account_key() -> Result<ServiceAccountKey> {
-    let json = env::var("GCLOUD_SERVICE_ACCOUNT_KEY")
-        .context("could not find GCLOUD_SERVICE_ACCOUNT_KEY value")?;
-    Ok(serde_json::from_str(&json)
-        .context("could not parse GCLOUD_SERVICE_ACCOUNT_KEY value")?)
+async fn service_account_key() -> Result<ServiceAccountKey> {
+    let creds = CredentialsManager::singleton()
+        .get("gcloud_service_account_key")
+        .await?;
+    Ok(serde_json::from_str(creds.get("value")?)
+        .context("could not parse service account key")?)
 }
 
 /// Build an authenticator using service account credentials.
 async fn service_account_authenticator() -> Result<Authenticator> {
     Ok(
-        yup_oauth2::ServiceAccountAuthenticator::builder(service_account_key()?)
+        yup_oauth2::ServiceAccountAuthenticator::builder(service_account_key().await?)
             .persist_tokens_to_disk(token_file_path()?)
             .build()
             .await
@@ -47,27 +49,26 @@ async fn service_account_authenticator() -> Result<Authenticator> {
     )
 }
 
-/// Our OAuth2 client secret. This is intended for use in a CLI application that
+/// Get the application secret needed to connect an interactive app to Google Cloud.
+///
+/// This is intended for use in a CLI application that
 /// gets distributed to end users, but it's not actually enough to authenticate
 /// against Google Cloud itself. It needs to be used together with a
 /// browser-based OAuth2 confirmation.
-const CLIENT_SECRET: &str = ""; // include_str!("client_secret.json");
-
-/// Get the application secret needed to connect an interactive app to BigQuery.
-fn application_secret() -> Result<ApplicationSecret> {
-    serde_json::from_str::<ConsoleApplicationSecret>(CLIENT_SECRET)
-        .context("built-in client_secret.json is invalid")?
+async fn application_secret() -> Result<ApplicationSecret> {
+    let creds = CredentialsManager::singleton()
+        .get("gcloud_client_secret")
+        .await?;
+    serde_json::from_str::<ConsoleApplicationSecret>(creds.get("value")?)
+        .context("could not parse client secret")?
         .installed
-        .ok_or_else(|| {
-            format_err!("built-in client_secret.json does not contain `installed` key")
-        })
+        .ok_or_else(|| format_err!("client secret does not contain `installed` key"))
 }
 
 /// Build an interactive authenticator for a CLI tool.
-#[allow(dead_code)]
 async fn installed_flow_authenticator() -> Result<Authenticator> {
     Ok(yup_oauth2::InstalledFlowAuthenticator::builder(
-        application_secret()?,
+        application_secret().await?,
         InstalledFlowReturnMethod::HTTPRedirect,
     )
     .persist_tokens_to_disk(token_file_path()?)
@@ -78,21 +79,17 @@ async fn installed_flow_authenticator() -> Result<Authenticator> {
 
 /// Create an authenticator using service account credentials if available, and
 /// interactive credentials otherwise.
-pub(crate) async fn authenticator(_ctx: &Context) -> Result<Authenticator> {
-    // We do not yet have an approved `client_secret.json`, so just require a
-    // service account for now.
-    service_account_authenticator().await
-
-    //match service_account_authenticator().await {
-    //    // We have a service account configured, so use it.
-    //    Ok(auth) => Ok(auth),
-    //    Err(err) => {
-    //        trace!(
-    //            ctx.log(),
-    //            "no service account found, using interactive auth: {}",
-    //            err,
-    //        );
-    //        installed_flow_authenticator().await
-    //    }
-    //}
+pub(crate) async fn authenticator(ctx: &Context) -> Result<Authenticator> {
+    match service_account_authenticator().await {
+        // We have a service account configured, so use it.
+        Ok(auth) => Ok(auth),
+        Err(err) => {
+            trace!(
+                ctx.log(),
+                "no service account found, using interactive auth: {}",
+                err,
+            );
+            installed_flow_authenticator().await
+        }
+    }
 }

--- a/dbcrossbarlib/src/credentials.rs
+++ b/dbcrossbarlib/src/credentials.rs
@@ -152,7 +152,7 @@ impl CredentialsManager {
             // credential. The `Display` method on `CredentialsSource` is
             // responsible for explaining how to set credentials.
             Err(format_err!(
-                "could not find credentials for {} in:\n{}",
+                "could not find credentials for {} in any of:\n{}",
                 name,
                 source,
             ))
@@ -224,11 +224,11 @@ impl EnvCredentialsSource {
 impl fmt::Display for EnvCredentialsSource {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.mapping.len() == 1 {
-            writeln!(f, "The environment variable {}", &self.mapping[0])
+            writeln!(f, "- The environment variable {}", &self.mapping[0])
         } else {
             writeln!(
                 f,
-                "The environment variables {}",
+                "- The environment variables {}",
                 self.mapping.iter().join(", "),
             )
         }
@@ -303,7 +303,7 @@ impl FileCredentialsSource {
 
 impl fmt::Display for FileCredentialsSource {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln!(f, "The file {}", self.path.display())
+        writeln!(f, "- The file {}", self.path.display())
     }
 }
 
@@ -344,9 +344,8 @@ impl CredentialsSources {
 
 impl fmt::Display for CredentialsSources {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln!(f, "One of:")?;
         for s in &self.sources {
-            write!(f, "- {}", s)?;
+            write!(f, "{}", s)?;
         }
         Ok(())
     }

--- a/dbcrossbarlib/src/credentials.rs
+++ b/dbcrossbarlib/src/credentials.rs
@@ -1,0 +1,365 @@
+//! Support for looking up credentials.
+
+use async_trait::async_trait;
+use dirs;
+use itertools::Itertools;
+use lazy_static::lazy_static;
+use std::{
+    collections::HashMap,
+    env, fmt,
+    path::PathBuf,
+    time::{Duration, Instant},
+};
+use tokio::{fs, sync::Mutex};
+
+use crate::common::*;
+
+/// A set of credentials that we can use to access a service.
+///
+/// This might be, for example, an account ID and an access key. A credential is
+/// a set of key/value pairs. In general, the keys will be named using the same
+/// naming conventions as the keys inside a vault secret.
+#[derive(Clone, Debug)]
+pub(crate) struct Credentials {
+    data: HashMap<String, String>,
+    expires: Option<Instant>,
+}
+
+impl Credentials {
+    /// Get the specied value for this credential.
+    pub(crate) fn get<'a>(&'a self, key: &str) -> Result<&'a str> {
+        self.data
+            .get(key)
+            .map(|v| &v[..])
+            .ok_or_else(|| format_err!("no key {:?} in credential", key))
+    }
+
+    /// Does this secret need to be refreshed?
+    fn needs_refresh(&self) -> bool {
+        if let Some(expires) = self.expires {
+            // Refresh any secret which will expire in the next 30 minutes.
+            let minimum_useful_expiration =
+                Instant::now() + Duration::from_secs(30 * 60);
+            expires < minimum_useful_expiration
+        } else {
+            false
+        }
+    }
+}
+
+lazy_static! {
+    /// Our `CredentialsManager` singleton.
+    ///
+    /// TODO: Figure out how to handle initialization errors without panicking.
+    static ref MANAGER: CredentialsManager = CredentialsManager::new().unwrap();
+}
+
+/// An interface which can be used to look up credentials.
+pub(crate) struct CredentialsManager {
+    /// Places to look up credentials.
+    ///
+    /// You must _always_ lock the appropriate key here _before_ locking `cache`
+    /// below.
+    sources: HashMap<String, Mutex<Box<dyn CredentialsSource>>>,
+
+    /// Credentials that we've already looked up. These may have expired.
+    ///
+    /// Before locking this, you must have locked exactly one key in `sources`.
+    cache: Mutex<HashMap<String, Credentials>>,
+}
+
+impl CredentialsManager {
+    /// Get the global singleton instance of `CredentialsManager`.
+    pub(crate) fn singleton() -> &'static CredentialsManager {
+        &MANAGER
+    }
+
+    /// Create a new credentials manager and install the default handlers.
+    fn new() -> Result<CredentialsManager> {
+        let mut sources = HashMap::new();
+        let config_dir = dirs::config_dir()
+            .ok_or_else(|| format_err!("could not find user config dir"))?
+            .join("dbcrossbar");
+
+        // Specify how to find Google Cloud service account keys.
+        let gcloud_service_account_key = CredentialsSources::new(vec![
+            EnvCredentialsSource::new(&[EnvMapping {
+                key: "value",
+                var: "GCLOUD_SERVICE_ACCOUNT_KEY",
+                optional: false,
+            }])
+            .boxed(),
+            FileCredentialsSource::new(
+                "value",
+                config_dir.join("gcloud_service_account_key.json"),
+            )
+            .boxed(),
+        ]);
+        sources.insert(
+            "gcloud_service_account_key".to_owned(),
+            Mutex::new(gcloud_service_account_key.boxed()),
+        );
+
+        // Specify how to find Google Cloud client secret.
+        let gcloud_client_secret = CredentialsSources::new(vec![
+            EnvCredentialsSource::new(&[EnvMapping {
+                key: "value",
+                var: "GCLOUD_CLIENT_SECRET",
+                optional: false,
+            }])
+            .boxed(),
+            FileCredentialsSource::new(
+                "value",
+                config_dir.join("gcloud_client_secret.json"),
+            )
+            .boxed(),
+        ]);
+        sources.insert(
+            "gcloud_client_secret".to_owned(),
+            Mutex::new(gcloud_client_secret.boxed()),
+        );
+
+        let cache = Mutex::new(HashMap::new());
+        Ok(CredentialsManager { sources, cache })
+    }
+
+    /// Look up the credential `name` and return it.
+    pub(crate) async fn get(&self, name: &str) -> Result<Credentials> {
+        // Look up our source and lock it. We _must_ do this before locking
+        // `cache`.
+        let source = self
+            .sources
+            .get(name)
+            .ok_or_else(|| format_err!("unknown credential {:?}", name))?;
+        let source = source.lock().await;
+
+        // See if we already have this secret in our cache. We need to be careful to
+        // not hold `self.cache.lock()` beyond the end of the line.
+        let credentials: Option<Credentials> =
+            self.cache.lock().await.get(name).map(|c| c.to_owned());
+        match credentials {
+            Some(c) if !c.needs_refresh() => return Ok(c),
+            _ => {}
+        }
+
+        // Try to look up these credentials.
+        if let Some(c) = source.get_credentials().await? {
+            // Cache it and return it.
+            self.cache.lock().await.insert(name.to_owned(), c.clone());
+            Ok(c)
+        } else {
+            // Explain to the user how they could have specified this
+            // credential. The `Display` method on `CredentialsSource` is
+            // responsible for explaining how to set credentials.
+            Err(format_err!(
+                "could not find credentials for {} in:\n{}",
+                name,
+                source,
+            ))
+        }
+    }
+}
+
+/// An interface for looking up credentials.
+///
+/// We use the `async_trait` macro, which allows async functions to be declared
+/// inside a trait. This isn't yet supported by standard Rust because there are
+/// some tricky design issues that still need to be settled.
+#[async_trait]
+trait CredentialsSource: fmt::Debug + fmt::Display + Send + Sync + 'static {
+    /// Look up an appropriate set of credentials.
+    async fn get_credentials(&self) -> Result<Option<Credentials>>;
+}
+
+/// Extra methods for `CredentialsSource` which aren't "object safe" and which
+/// would prevent us from using `dyn CredentialsSource` if we put them in
+/// `CredentialsSource`.
+trait CredentialsSourceExt: CredentialsSource + Sized + 'static {
+    /// Convert to a `Box<dyn CredentialsSource>`.
+    fn boxed(self) -> Box<dyn CredentialsSource> {
+        Box::new(self)
+    }
+}
+
+impl<CS: CredentialsSource> CredentialsSourceExt for CS {}
+
+/// A mapping from a `Credentials` key name to an environment variable.
+#[derive(Debug)]
+struct EnvMapping {
+    key: &'static str,
+    var: &'static str,
+    optional: bool,
+}
+
+impl fmt::Display for EnvMapping {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if self.optional {
+            write!(f, "(optional) {}", self.var)
+        } else {
+            write!(f, "{}", self.var)
+        }
+    }
+}
+
+/// Look up credentials stored in environment variables.
+#[derive(Debug)]
+struct EnvCredentialsSource {
+    mapping: &'static [EnvMapping],
+}
+
+impl EnvCredentialsSource {
+    /// Create a new `EnvCredentialsSource`.
+    ///
+    /// `mapping` should contain at least one element. The first element must
+    /// not be `optional`.
+    fn new(mapping: &'static [EnvMapping]) -> Self {
+        // Check our preconditions with assertions, since all callers will be
+        // hard-coded in the source.
+        assert!(!mapping.is_empty());
+        assert!(!mapping[0].optional);
+        Self { mapping }
+    }
+}
+
+impl fmt::Display for EnvCredentialsSource {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if self.mapping.len() == 1 {
+            writeln!(f, "The environment variable {}", &self.mapping[0])
+        } else {
+            writeln!(
+                f,
+                "The environment variables {}",
+                self.mapping.iter().join(", "),
+            )
+        }
+    }
+}
+
+#[async_trait]
+impl CredentialsSource for EnvCredentialsSource {
+    async fn get_credentials(&self) -> Result<Option<Credentials>> {
+        if let Some(value) = try_var(self.mapping[0].var)? {
+            // Our first environment variable is present
+            let mut data = HashMap::new();
+            data.insert(self.mapping[0].key.to_owned(), value);
+            for m in &self.mapping[1..] {
+                if m.optional {
+                    if let Some(value) = try_var(&m.var)? {
+                        data.insert(m.key.to_owned(), value);
+                    }
+                } else {
+                    data.insert(m.key.to_owned(), var(&m.var)?);
+                }
+            }
+            Ok(Some(Credentials {
+                data,
+                expires: None,
+            }))
+        } else {
+            // The necessary environment varaibles are not set.
+            Ok(None)
+        }
+    }
+}
+
+/// Look up an environment variable by name, returning `Ok(None)` if it does not
+/// exist.
+fn try_var(name: &str) -> Result<Option<String>> {
+    match env::var(name) {
+        Ok(value) => Ok(Some(value)),
+        Err(env::VarError::NotPresent) => Ok(None),
+        Err(env::VarError::NotUnicode(..)) => Err(format_err!(
+            "environment variable {} cannot be converted to UTF-8",
+            name,
+        )),
+    }
+}
+
+/// Look up an environment variable by name, returning an error if it does not exist.
+fn var(name: &str) -> Result<String> {
+    match try_var(name)? {
+        Some(value) => Ok(value),
+        None => Err(format_err!(
+            "expected evironment variable {} to be set",
+            name,
+        )),
+    }
+}
+
+/// Load credentials stored in a file.
+#[derive(Debug)]
+struct FileCredentialsSource {
+    key: &'static str,
+    path: PathBuf,
+}
+
+impl FileCredentialsSource {
+    /// Specify how to find credentials in a file. The contents of the file will
+    /// be mapped to `key` in the credential.
+    fn new(key: &'static str, path: PathBuf) -> Self {
+        Self { key, path }
+    }
+}
+
+impl fmt::Display for FileCredentialsSource {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "The file {}", self.path.display())
+    }
+}
+
+#[async_trait]
+impl CredentialsSource for FileCredentialsSource {
+    async fn get_credentials(&self) -> Result<Option<Credentials>> {
+        match fs::read_to_string(&self.path).await {
+            Ok(value) => {
+                let mut data = HashMap::new();
+                data.insert(self.key.to_owned(), value);
+                Ok(Some(Credentials {
+                    data,
+                    expires: None,
+                }))
+            }
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(err) => Err(format_err!(
+                "error reading {}: {}",
+                self.path.display(),
+                err
+            )),
+        }
+    }
+}
+
+/// Look in multiple places for credentials.
+#[derive(Debug)]
+struct CredentialsSources {
+    sources: Vec<Box<dyn CredentialsSource>>,
+}
+
+impl CredentialsSources {
+    /// Create a new list of credentials sources that will be searched in order.
+    fn new(sources: Vec<Box<dyn CredentialsSource>>) -> Self {
+        Self { sources }
+    }
+}
+
+impl fmt::Display for CredentialsSources {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "One of:")?;
+        for s in &self.sources {
+            write!(f, "- {}", s)?;
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl CredentialsSource for CredentialsSources {
+    async fn get_credentials(&self) -> Result<Option<Credentials>> {
+        for source in &self.sources {
+            if let Some(credentials) = source.get_credentials().await? {
+                return Ok(Some(credentials));
+            }
+        }
+        Ok(None)
+    }
+}

--- a/dbcrossbarlib/src/lib.rs
+++ b/dbcrossbarlib/src/lib.rs
@@ -18,6 +18,7 @@ pub(crate) mod args;
 pub(crate) mod clouds;
 pub(crate) mod concat;
 pub(crate) mod context;
+pub(crate) mod credentials;
 pub(crate) mod csv_stream;
 mod driver_args;
 pub mod drivers;

--- a/guide/src/bigquery.md
+++ b/guide/src/bigquery.md
@@ -12,7 +12,7 @@ When loading data into BigQuery, or extracting it, we always go via Google Cloud
 
 ## Configuration & authentication
 
-Right now, all authentication is handled using `gcloud auth` from the [Google Cloud SDK](https://cloud.google.com/sdk/). **This will change in a future release.**
+See [the Cloud Storage driver](./gs.html#configuration--authentication) for authentication details.
 
 The following command-line options will usually need to be specified for both sources and destinations:
 

--- a/guide/src/gs.md
+++ b/guide/src/gs.md
@@ -17,12 +17,12 @@ At this point, we do not support single-file output to a cloud bucket. This is r
 
 ## Configuration & authentication
 
-**0.3.x and earlier:** Agll authentication is handled using `gcloud auth` from the [Google Cloud SDK](https://cloud.google.com/sdk/).
+**0.3.x and earlier:** All authentication is handled using `gcloud auth` from the [Google Cloud SDK](https://cloud.google.com/sdk/).
 
 **0.4.x and later:** You can authenticate using either a client secret or a service key, which you can create using the [console credentials page](https://console.cloud.google.com/apis/credentials).
 
-- Client secrets are can be stored in `~/.dbcrossbar/config/gcloud_client_secret.json` or in `GCLOUD_CLIENT_SECRET`. These are strongly recommended for interactive use.
-- Service account keys can be stored in `~/.dbcrossbar/config/gcloud_service_account_key.json` or in `GCLOUD_SERVICE_ACCOUNT_KEY`.
+- Client secrets can be stored in `~/.dbcrossbar/config/gcloud_client_secret.json` or in `GCLOUD_CLIENT_SECRET`. These are strongly recommended for interactive use.
+- Service account keys can be stored in `~/.dbcrossbar/config/gcloud_service_account_key.json` or in `GCLOUD_SERVICE_ACCOUNT_KEY`. These are recommended for server and container use.
 
 For a service account, you can use the following permissions:
 

--- a/guide/src/gs.md
+++ b/guide/src/gs.md
@@ -2,8 +2,6 @@
 
 Google Cloud Storage is a bucket-based storage system similar to Amazon's S3. It's frequently used in connection with BigQuery and other Google Cloud services.
 
-**COMPATIBILITY WARNING:** This driver currently relies on `gsutil` for many tasks, but `gsutil` is poorly-suited to the kind of automation we need. In particular, `gsutil` uses too much RAM, and has poor timeout behavio. We plan to replace it with native Rust libraries at some point. This will change how the Cloud Storage driver handles authentication in a future version.
-
 ## Example locators
 
 Source locators:
@@ -19,7 +17,21 @@ At this point, we do not support single-file output to a cloud bucket. This is r
 
 ## Configuration & authentication
 
-Right now, all authentication is handled using `gcloud auth` from the [Google Cloud SDK](https://cloud.google.com/sdk/). **This will change in a future release.**
+**0.3.x and earlier:** Agll authentication is handled using `gcloud auth` from the [Google Cloud SDK](https://cloud.google.com/sdk/).
+
+**0.4.x and later:** You can authenticate using either a client secret or a service key, which you can create using the [console credentials page](https://console.cloud.google.com/apis/credentials).
+
+- Client secrets are can be stored in `~/.dbcrossbar/config/gcloud_client_secret.json` or in `GCLOUD_CLIENT_SECRET`. These are strongly recommended for interactive use.
+- Service account keys can be stored in `~/.dbcrossbar/config/gcloud_service_account_key.json` or in `GCLOUD_SERVICE_ACCOUNT_KEY`.
+
+For a service account, you can use the following permissions:
+
+- Storage Object Admin (Cloud Storage and BigQuery drivers)
+- BigQuery Data Editor (BigQuery driver only)
+- BigQuery Job User (BigQuery driver only)
+- BigQuery User (BigQuery driver only)
+
+There's probably a more limited set of permissions which will work if you set them up manually.
 
 ## Supported features
 

--- a/guide/src/installing.md
+++ b/guide/src/installing.md
@@ -11,9 +11,9 @@ Windows binaries are not available at this time, but it may be possible to build
 
 To use the S3 and RedShift drivers, you will need to install the [AWS CLI tools](https://aws.amazon.com/cli/).
 
-To use the BigQuery and Google Cloud Storage drivers, you will need to install the [Google Cloud SDK](https://cloud.google.com/sdk/) to get the `gsutil` and `bq` CLI tools, and you will need to authenticate to your Google Cloud account using `gcloud`.
+**Versions 0.3.x and earlier only:** To use the BigQuery and Google Cloud Storage drivers, you will need to install the [Google Cloud SDK](https://cloud.google.com/sdk/) to get the `gsutil` and `bq` CLI tools, and you will need to authenticate to your Google Cloud account using `gcloud`.
 
-We plan to replace these external CLI tools with native Rust libraries before the 1.0 release.
+We plan to replace all external CLI tools with native Rust libraries before the 1.0 release.
 
 ## Installing using `cargo`
 


### PR DESCRIPTION
This PR includes two important missing pieces that we need for an alpha release:

- Support for `~/.config/dbcrossbar/gcloud_client_secret.json`.
- Documentation updates for the new native Rust drivers, including the authentication changes.

Once this is merged, I'll need an hour or so at some point to actually prepare an alpha release.