### PR TITLE
gcloud: Automatically create `~/.local/share`

### DIFF
--- a/dbcrossbarlib/src/clouds/gcloud/client.rs
+++ b/dbcrossbarlib/src/clouds/gcloud/client.rs
@@ -223,7 +223,11 @@ impl Client {
 
     /// Get an access token.
     async fn token(&self) -> Result<AccessToken> {
-        Ok(self.authenticator.token(SCOPES).await?)
+        Ok(self
+            .authenticator
+            .token(SCOPES)
+            .await
+            .context("could not get Google Cloud OAuth2 token")?)
     }
 
     /// Handle an HTTP response.


### PR DESCRIPTION
We need this directory to store GCloud tokens, and `yup_oauth2` doesn't
create it. We also improve the error message if `yup_oauth2` fails.