### PR TITLE
Implement a CLI-editable config file (#116)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "rust-analyzer.cargo-watch.command": "clippy"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,11 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "ascii"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "async-trait"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +254,18 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "combine"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ascii 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -505,6 +522,7 @@ dependencies = [
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-postgres 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml_edit 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1030,6 +1048,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "libc"
 version = "0.2.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2204,6 +2227,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "combine 3.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2266,6 +2299,14 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2298,6 +2339,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "version_check"
 version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "void"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2484,6 +2530,7 @@ dependencies = [
 "checksum arc-swap 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d663a8e9a99154b5fb793032533f6328da35e23aac63d5c152279aa8ba356825"
 "checksum arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 "checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+"checksum ascii 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 "checksum async-trait 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)" = "da71fef07bc806586090247e971229289f64c210a278ee5ae419314eb386b31d"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
@@ -2511,6 +2558,7 @@ dependencies = [
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cli_test_dir 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "2bc63338a59538d4f4b767dfb6082e4d26736aadb5100894b76039a04d6ad519"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum combine 3.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
 "checksum common_failures 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c84afb517ac0988b7e049e06c51511716f80d0f0233972fca666d3f14f80d8fb"
 "checksum constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 "checksum core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
@@ -2590,6 +2638,7 @@ dependencies = [
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)" = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
+"checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum lock_api 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "79b2de95ecb4691949fea4716ca53cdbcfccb2c612e19644a8bad05edcf9f47b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
@@ -2717,6 +2766,7 @@ dependencies = [
 "checksum tokio-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7bde02a3a5291395f59b06ec6945a3077602fac2b07eeeaf0dee2122f3619828"
 "checksum tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
 "checksum tokio-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
+"checksum toml_edit 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87f53b1aca7d5fe2e17498a38cac0e1f5a33234d5b980fb36b9402bb93b98ae4"
 "checksum tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b"
@@ -2727,12 +2777,14 @@ dependencies = [
 "checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60369ef7a31de49bcb3f6ca728d4ba7300d9a1658f94c727d4cab8c8d9f4aece"
 "checksum url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
 "checksum uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 "checksum vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 "checksum want 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 "checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"

--- a/dbcrossbar/src/cmd/config.rs
+++ b/dbcrossbar/src/cmd/config.rs
@@ -1,0 +1,79 @@
+//! The `config` subcommand.
+
+use common_failures::Result;
+use dbcrossbarlib::{
+    config::{Configuration, Key},
+    tokio_glue::spawn_blocking,
+    Context,
+};
+use failure::format_err;
+use structopt::{self, StructOpt};
+
+/// Configutation-editing arguments.
+#[derive(Debug, StructOpt)]
+pub(crate) struct Opt {
+    /// The command to perform on the configuration key.
+    #[structopt(subcommand)]
+    command: Command,
+}
+
+/// Shared options that specify a key.
+#[derive(Debug, StructOpt)]
+pub(crate) struct KeyOpt {
+    /// The configuration key to operate on [values: temporary].
+    key: String,
+    // We'll probably extend this with options for driver-specific and
+    // host-specific keys at some point.
+}
+
+impl KeyOpt {
+    /// Get our configuration key.
+    fn to_key(&self) -> Result<Key<'static>> {
+        match &self.key[..] {
+            "temporary" => Ok(Key::temporary()),
+            other => Err(format_err!("unknown configuration key {:?}", other)),
+        }
+    }
+}
+
+/// A command that we can perform on a config key.
+#[derive(Debug, StructOpt)]
+pub(crate) enum Command {
+    /// Add the specified value to the configuration key if it isn't already there.
+    #[structopt(name = "add")]
+    Add {
+        #[structopt(flatten)]
+        key: KeyOpt,
+
+        /// The value to add.
+        value: String,
+    },
+
+    /// Remove the specified value from the configuration key if it isn't
+    /// already there.
+    #[structopt(name = "rm")]
+    Remove {
+        #[structopt(flatten)]
+        key: KeyOpt,
+
+        /// The value to remove.
+        value: String,
+    },
+}
+
+/// Edit our config file.
+pub(crate) async fn run(
+    _ctx: Context,
+    mut config: Configuration,
+    opt: Opt,
+) -> Result<()> {
+    match &opt.command {
+        Command::Add { key, value } => {
+            config.add_to_string_array(&key.to_key()?, value)?;
+        }
+        Command::Remove { key, value } => {
+            config.remove_from_string_array(&key.to_key()?, value)?;
+        }
+    }
+    spawn_blocking(move || config.write()).await
+}

--- a/dbcrossbar/src/cmd/conv.rs
+++ b/dbcrossbar/src/cmd/conv.rs
@@ -1,7 +1,7 @@
 //! The `conv` subcommand.
 
 use common_failures::Result;
-use dbcrossbarlib::{BoxLocator, Context, IfExists};
+use dbcrossbarlib::{config::Configuration, BoxLocator, Context, IfExists};
 use failure::format_err;
 use structopt::{self, StructOpt};
 
@@ -20,7 +20,7 @@ pub(crate) struct Opt {
 }
 
 /// Perform our schema conversion.
-pub(crate) async fn run(ctx: Context, opt: Opt) -> Result<()> {
+pub(crate) async fn run(ctx: Context, _config: Configuration, opt: Opt) -> Result<()> {
     let schema = opt.from_locator.schema(ctx.clone()).await?.ok_or_else(|| {
         format_err!("don't know how to read schema from {}", opt.from_locator)
     })?;

--- a/dbcrossbar/src/cmd/count.rs
+++ b/dbcrossbar/src/cmd/count.rs
@@ -2,8 +2,8 @@
 
 use common_failures::Result;
 use dbcrossbarlib::{
-    BoxLocator, Context, DriverArguments, SharedArguments, SourceArguments,
-    TemporaryStorage,
+    config::Configuration, BoxLocator, Context, DriverArguments, SharedArguments,
+    SourceArguments, TemporaryStorage,
 };
 use failure::{format_err, ResultExt};
 use structopt::{self, StructOpt};
@@ -33,7 +33,7 @@ pub(crate) struct Opt {
 }
 
 /// Count records.
-pub(crate) async fn run(ctx: Context, opt: Opt) -> Result<()> {
+pub(crate) async fn run(ctx: Context, config: Configuration, opt: Opt) -> Result<()> {
     // Figure out what table schema to use.
     let schema = {
         let schema_locator = opt.schema.as_ref().unwrap_or(&opt.locator);
@@ -48,7 +48,8 @@ pub(crate) async fn run(ctx: Context, opt: Opt) -> Result<()> {
 
     // Build our shared arguments. Specify 1 for `max_streams` until we actually
     // implement local counting.
-    let temporary_storage = TemporaryStorage::new(opt.temporaries.clone());
+    let temporaries = opt.temporaries.clone();
+    let temporary_storage = TemporaryStorage::with_config(temporaries, &config)?;
     let shared_args = SharedArguments::new(schema, temporary_storage, 1);
 
     // Build our source arguments.

--- a/dbcrossbar/src/cmd/features.rs
+++ b/dbcrossbar/src/cmd/features.rs
@@ -2,6 +2,7 @@
 
 use common_failures::Result;
 use dbcrossbarlib::{
+    config::Configuration,
     drivers::{all_drivers, find_driver},
     Context,
 };
@@ -15,7 +16,11 @@ pub(crate) struct Opt {
 }
 
 /// Perform our schema conversion.
-pub(crate) async fn run(_ctx: Context, opt: Opt) -> Result<()> {
+pub(crate) async fn run(
+    _ctx: Context,
+    _config: Configuration,
+    opt: Opt,
+) -> Result<()> {
     if let Some(name) = &opt.driver {
         let scheme = format!("{}:", name);
         let driver = find_driver(&scheme)?;

--- a/dbcrossbar/src/cmd/mod.rs
+++ b/dbcrossbar/src/cmd/mod.rs
@@ -1,12 +1,13 @@
 //! Command parsing.
 
-use dbcrossbarlib::{tokio_glue::BoxFuture, Context};
+use dbcrossbarlib::{config::Configuration, tokio_glue::BoxFuture, Context};
 use futures::FutureExt;
 //use structopt::StructOpt;
 use structopt_derive::StructOpt;
 
 use crate::logging::LogFormat;
 
+pub(crate) mod config;
 pub(crate) mod conv;
 pub(crate) mod count;
 pub(crate) mod cp;
@@ -35,6 +36,13 @@ pub(crate) struct Opt {
 /// The command to run.
 #[derive(Debug, StructOpt)]
 pub(crate) enum Command {
+    /// Update configuration.
+    #[structopt(name = "config")]
+    Config {
+        #[structopt(flatten)]
+        command: config::Opt,
+    },
+
     /// Convert table schemas from one format to another.
     #[structopt(name = "conv")]
     #[structopt(after_help = r#"EXAMPLE LOCATORS:
@@ -77,11 +85,12 @@ pub(crate) enum Command {
     },
 }
 
-pub(crate) fn run(ctx: Context, opt: Opt) -> BoxFuture<()> {
+pub(crate) fn run(ctx: Context, config: Configuration, opt: Opt) -> BoxFuture<()> {
     match opt.cmd {
-        Command::Conv { command } => conv::run(ctx, command).boxed(),
-        Command::Count { command } => count::run(ctx, command).boxed(),
-        Command::Cp { command } => cp::run(ctx, command).boxed(),
-        Command::Features { command } => features::run(ctx, command).boxed(),
+        Command::Config { command } => config::run(ctx, config, command).boxed(),
+        Command::Conv { command } => conv::run(ctx, config, command).boxed(),
+        Command::Count { command } => count::run(ctx, config, command).boxed(),
+        Command::Cp { command } => cp::run(ctx, config, command).boxed(),
+        Command::Features { command } => features::run(ctx, config, command).boxed(),
     }
 }

--- a/dbcrossbar/src/logging.rs
+++ b/dbcrossbar/src/logging.rs
@@ -3,8 +3,6 @@
 use dbcrossbarlib::{Error, Result};
 use failure::format_err;
 use slog::{error, slog_o as o, Drain, Logger, Never};
-use slog_json;
-use slog_term;
 use std::{io::stderr, result, str::FromStr};
 
 /// A polymorphic log drain (which means we need to use `Box<dyn ...>`,

--- a/dbcrossbar/src/main.rs
+++ b/dbcrossbar/src/main.rs
@@ -12,7 +12,7 @@ extern crate openssl;
 extern crate tokio;
 
 use common_failures::{quick_main, Result};
-use dbcrossbarlib::{run_futures_with_runtime, Context};
+use dbcrossbarlib::{config::Configuration, run_futures_with_runtime, Context};
 use env_logger;
 use openssl_probe;
 use slog::{debug, Drain};
@@ -59,8 +59,12 @@ fn run() -> Result<()> {
     // Log our command-line options.
     debug!(ctx.log(), "{:?}", opt);
 
+    // Load our configuration.
+    let config = Configuration::try_default()?;
+    debug!(ctx.log(), "{:?}", config);
+
     // Create a future to run our command.
-    let cmd_fut = cmd::run(ctx, opt);
+    let cmd_fut = cmd::run(ctx, config, opt);
 
     // Run our futures.
     run_futures_with_runtime(cmd_fut, worker_fut)

--- a/dbcrossbar/src/main.rs
+++ b/dbcrossbar/src/main.rs
@@ -13,11 +13,8 @@ extern crate tokio;
 
 use common_failures::{quick_main, Result};
 use dbcrossbarlib::{config::Configuration, run_futures_with_runtime, Context};
-use env_logger;
-use openssl_probe;
 use slog::{debug, Drain};
 use slog_async::{self, OverflowStrategy};
-use slog_envlogger;
 use structopt::{self, StructOpt};
 
 mod cmd;

--- a/dbcrossbarlib/Cargo.toml
+++ b/dbcrossbarlib/Cargo.toml
@@ -62,6 +62,7 @@ strum = "0.18.0"
 strum_macros = "0.18.0"
 tempdir = "0.3.7"
 tokio = { version = "0.2.6", features = ["fs", "io-std", "io-util", "process", "stream", "sync", "time"] }
+toml_edit = "0.1.5"
 try_from = "0.3.2"
 url = "2.1.0"
 uuid = "0.8.1"

--- a/dbcrossbarlib/build.rs
+++ b/dbcrossbarlib/build.rs
@@ -1,8 +1,6 @@
 //! This script is called before compiling this library. Its job is to generate
 //! source code which will be added to the build.
 
-use peg;
-
 fn main() {
     // Run our parser generator over our grammars.
     peg::cargo_build("src/drivers/bigquery_shared/data_type.rustpeg");

--- a/dbcrossbarlib/src/clouds/aws/signing.rs
+++ b/dbcrossbarlib/src/clouds/aws/signing.rs
@@ -1,6 +1,5 @@
 //! S3 URL signing.
 
-use base64;
 use chrono::{DateTime, Utc};
 use hmac::{Hmac, Mac};
 use sha1::Sha1;

--- a/dbcrossbarlib/src/clouds/gcloud/auth.rs
+++ b/dbcrossbarlib/src/clouds/gcloud/auth.rs
@@ -1,9 +1,7 @@
 //! Authentication support for Google Cloud.
 
-use dirs;
 use hyper::{self, client::connect::HttpConnector};
 use hyper_rustls::HttpsConnector;
-use serde_json;
 use std::path::PathBuf;
 use tokio::fs;
 pub(crate) use yup_oauth2::AccessToken;

--- a/dbcrossbarlib/src/clouds/gcloud/bigquery/queries.rs
+++ b/dbcrossbarlib/src/clouds/gcloud/bigquery/queries.rs
@@ -187,7 +187,7 @@ where
     let output = query_all_json(ctx, project, sql).await?;
     let rows = output
         .into_iter()
-        .map(|row| serde_json::from_value::<T>(row))
+        .map(serde_json::from_value::<T>)
         .collect::<Result<Vec<T>, _>>()
         .context("could not parse count output")?;
     Ok(rows)

--- a/dbcrossbarlib/src/clouds/gcloud/bigquery/queries.rs
+++ b/dbcrossbarlib/src/clouds/gcloud/bigquery/queries.rs
@@ -1,7 +1,6 @@
 //! Running queries against BigQuery.
 
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use serde_json;
 use std::convert::TryFrom;
 
 use super::{

--- a/dbcrossbarlib/src/clouds/gcloud/client.rs
+++ b/dbcrossbarlib/src/clouds/gcloud/client.rs
@@ -4,7 +4,6 @@ use failure::ResultExt;
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use reqwest::{self, header::HeaderMap, IntoUrl};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use serde_urlencoded;
 use std::{error, fmt};
 
 use super::auth::{authenticator, AccessToken, Authenticator};

--- a/dbcrossbarlib/src/config.rs
+++ b/dbcrossbarlib/src/config.rs
@@ -1,0 +1,240 @@
+//! Configuration file support.
+
+use dirs;
+use failure::Fail;
+use std::{
+    env, fmt,
+    fs::{create_dir_all, File},
+    io::{self, Read},
+    path::{Path, PathBuf},
+};
+use toml_edit::{Array, Document, Item, Value};
+
+use crate::common::*;
+
+/// Find the path to our configuration directory.
+pub(crate) fn config_dir() -> Result<PathBuf> {
+    // Use `var_os` instead of `var`, because if it returns a non-Unicode path,
+    // we can hand it off directly to `PathBuf`.
+    match env::var_os("DBCROSSBAR_CONFIG_DIR") {
+        // The user specified a config directory, so use that.
+        Some(dir) => Ok(PathBuf::from(dir)),
+        // Use `dbcrossbar/` in the system configuration directory.
+        None => Ok(dirs::config_dir()
+            // AFAIK, this only fails under weird conditions, such as no home
+            // directory.
+            .ok_or_else(|| format_err!("could not find user config dir"))?
+            .join("dbcrossbar")),
+    }
+}
+
+/// Find the path to our configuration file.
+pub(crate) fn config_file() -> Result<PathBuf> {
+    Ok(config_dir()?.join("dbcrossbar.toml"))
+}
+
+/// A configuration file key.
+///
+/// This is opaque to allow for driver-specific and host-specific keys in the
+/// future.
+#[derive(Debug)]
+pub struct Key<'a> {
+    /// The key in the TOML file.
+    key: &'a str,
+}
+
+impl Key<'_> {
+    /// A key for accessing `temporary`
+    pub fn temporary() -> Key<'static> {
+        Self::global("temporary")
+    }
+
+    /// A top-level configuration key.
+    pub(crate) fn global<'a>(key: &'a str) -> Key<'a> {
+        Key { key }
+    }
+}
+
+impl<'a> fmt::Display for Key<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.key.fmt(f)
+    }
+}
+
+/// Our `dbcrossbar.toml` configuration file.
+#[derive(Debug)]
+pub struct Configuration {
+    /// The path from which we read this file.
+    path: PathBuf,
+    /// Our raw configuration data.
+    doc: Document,
+}
+
+// A lot of the implementation of `Configuration` is fairly verbose, because
+// we're using `toml_edit`. The upside of `toml_edit` is that it allows us to
+// load, edit and configuration file without losing whitespace or comments that
+// the user had in the file. The downside is that it's not nearly as nice as
+// `serde`, and we have to manipulate a lot of dynamic, untyped data in Rust.
+// This tends to be more verbose than either using `serde` or writing similar
+// code in Ruby. But on the other hand: We can edit files with comments in them!
+impl Configuration {
+    /// Load our default configuration.
+    pub fn try_default() -> Result<Self> {
+        Self::from_path(&config_file()?)
+    }
+
+    /// Load the configuration file at `path`.
+    pub(crate) fn from_path(path: &Path) -> Result<Self> {
+        match File::open(&path) {
+            Ok(rdr) => {
+                Ok(Self::from_reader(path.to_owned(), rdr).with_context(|_| {
+                    format!("could not read file {}", path.display())
+                })?)
+            }
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(Self {
+                path: path.to_owned(),
+                doc: Document::default(),
+            }),
+            Err(err) => Err(err
+                .context(format!("could not open file {}", path.display()))
+                .into()),
+        }
+    }
+
+    /// Load a configuration file from the specified reader.
+    fn from_reader<R>(path: PathBuf, mut rdr: R) -> Result<Self>
+    where
+        R: Read + 'static,
+    {
+        let mut buf = String::new();
+        rdr.read_to_string(&mut buf)?;
+        let doc = buf.parse::<Document>()?;
+        Ok(Self { path, doc })
+    }
+
+    /// Write the configuration file to disk.
+    pub fn write(&self) -> Result<()> {
+        let parent = self.path.parent().ok_or_else(|| {
+            format_err!("cannot find parent directory of {}", self.path.display())
+        })?;
+        create_dir_all(&parent)
+            .with_context(|_| format!("cannot create {}", parent.display()))?;
+        let data = self.doc.to_string_in_original_order();
+        let mut f = File::create(&self.path)
+            .with_context(|_| format!("cannot create {}", self.path.display()))?;
+        f.write_all(data.as_bytes())
+            .with_context(|_| format!("error writing to {}", self.path.display()))?;
+        f.flush()
+            .with_context(|_| format!("error writing to {}", self.path.display()))?;
+        Ok(())
+    }
+
+    /// Return a list of places to store temporary data.
+    pub fn temporaries(&self) -> Result<Vec<String>> {
+        self.string_array(&Key::global("temporary"))
+    }
+
+    /// Get an array of strings from our config file.
+    fn string_array(&self, key: &Key<'_>) -> Result<Vec<String>> {
+        let mut temps = vec![];
+        if let Some(raw_value) = self.doc.as_table().get(key.key) {
+            if let Some(raw_array) = raw_value.as_array() {
+                for raw_item in raw_array.iter() {
+                    if let Some(temp) = raw_item.as_str() {
+                        temps.push(temp.to_owned());
+                    } else {
+                        return Err(format_err!(
+                            "expected string, found {:?} in {}",
+                            raw_item,
+                            self.path.display(),
+                        ));
+                    }
+                }
+            } else {
+                return Err(format_err!(
+                    "expected array, found {:?} in {}",
+                    raw_value,
+                    self.path.display(),
+                ));
+            }
+        }
+        Ok(temps)
+    }
+
+    /// Get our an array of strings in mutable form.
+    fn raw_string_array_mut<'a, 'b>(
+        &mut self,
+        key: &'a Key<'b>,
+    ) -> Result<&mut Array> {
+        let array_value = self
+            .doc
+            .as_table_mut()
+            .entry(key.key)
+            .or_insert(Item::Value(Value::Array(Array::default())));
+        match array_value.as_array_mut() {
+            Some(array) => Ok(array),
+            None => Err(format_err!(
+                "expected array for {} in {}",
+                key,
+                self.path.display(),
+            )),
+        }
+    }
+
+    /// Add a new value to an array of strings, if it's not already there.
+    pub fn add_to_string_array(&mut self, key: &Key<'_>, value: &str) -> Result<()> {
+        let raw_array = self.raw_string_array_mut(key)?;
+        for raw_item in raw_array.iter() {
+            if raw_item.as_str() == Some(value) {
+                // Already present, so don't add it again.
+                return Ok(());
+            }
+        }
+        raw_array.push(value);
+        raw_array.fmt();
+        Ok(())
+    }
+
+    /// Remove a value from an array of strings, if present. If more
+    /// than one copy is present it will remove all.
+    pub fn remove_from_string_array(
+        &mut self,
+        key: &Key<'_>,
+        value: &str,
+    ) -> Result<()> {
+        let raw_array = self.raw_string_array_mut(key)?;
+
+        // Find matches.
+        let mut indices = vec![];
+        for (idx, raw_item) in raw_array.iter().enumerate() {
+            if raw_item.as_str() == Some(value) {
+                indices.push(idx);
+            }
+        }
+
+        // Remove in reverse order to avoid invalidating indices.
+        for idx in indices.iter().rev().cloned() {
+            raw_array.remove(idx);
+        }
+        raw_array.fmt();
+        Ok(())
+    }
+}
+
+#[test]
+fn temporaries_can_be_added_and_removed() {
+    let temp = tempdir::TempDir::new("dbcrossbar_test").unwrap();
+    let path = temp.path().join("dbcrossbar.toml");
+    let mut config = Configuration::from_path(&path).unwrap();
+    let key = Key::global("temporary");
+    assert_eq!(config.temporaries().unwrap(), Vec::<String>::new());
+    config.add_to_string_array(&key, "s3://example/").unwrap();
+    assert_eq!(config.temporaries().unwrap(), &["s3://example/".to_owned()]);
+    config.write().unwrap();
+    config = Configuration::from_path(&path).unwrap();
+    assert_eq!(config.temporaries().unwrap(), &["s3://example/".to_owned()]);
+    config
+        .remove_from_string_array(&key, "s3://example/")
+        .unwrap();
+    assert_eq!(config.temporaries().unwrap(), Vec::<String>::new());
+}

--- a/dbcrossbarlib/src/config.rs
+++ b/dbcrossbarlib/src/config.rs
@@ -1,6 +1,5 @@
 //! Configuration file support.
 
-use dirs;
 use failure::Fail;
 use std::{
     env, fmt,

--- a/dbcrossbarlib/src/config.rs
+++ b/dbcrossbarlib/src/config.rs
@@ -49,7 +49,7 @@ impl Key<'_> {
     }
 
     /// A top-level configuration key.
-    pub(crate) fn global<'a>(key: &'a str) -> Key<'a> {
+    pub(crate) fn global(key: &str) -> Key<'_> {
         Key { key }
     }
 }

--- a/dbcrossbarlib/src/credentials.rs
+++ b/dbcrossbarlib/src/credentials.rs
@@ -1,7 +1,6 @@
 //! Support for looking up credentials.
 
 use async_trait::async_trait;
-use dirs;
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use std::{
@@ -13,6 +12,7 @@ use std::{
 use tokio::{fs, sync::Mutex};
 
 use crate::common::*;
+use crate::config::config_dir;
 
 /// A set of credentials that we can use to access a service.
 ///
@@ -77,9 +77,7 @@ impl CredentialsManager {
     /// Create a new credentials manager and install the default handlers.
     fn new() -> Result<CredentialsManager> {
         let mut sources = HashMap::new();
-        let config_dir = dirs::config_dir()
-            .ok_or_else(|| format_err!("could not find user config dir"))?
-            .join("dbcrossbar");
+        let config_dir = config_dir()?;
 
         // Specify how to find Google Cloud service account keys.
         let gcloud_service_account_key = CredentialsSources::new(vec![

--- a/dbcrossbarlib/src/csv_stream.rs
+++ b/dbcrossbarlib/src/csv_stream.rs
@@ -53,7 +53,7 @@ impl CsvStream {
             }
         }
         trace!(ctx.log(), "end of stream");
-        return Ok(bytes);
+        Ok(bytes)
     }
 
     /// Convert an HTTP `Body` into a `CsvStream`.

--- a/dbcrossbarlib/src/drivers/bigml/schema.rs
+++ b/dbcrossbarlib/src/drivers/bigml/schema.rs
@@ -1,7 +1,5 @@
 //! Implementation of `schema`.
 
-use bigml;
-
 use super::{data_type::OptypeExt, BigMlAction, BigMlLocator};
 use crate::common::*;
 use crate::schema::{Column, Table};

--- a/dbcrossbarlib/src/drivers/bigquery_shared/column_name.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/column_name.rs
@@ -158,7 +158,7 @@ impl<'de> Deserialize<'de> for ColumnName {
         D: Deserializer<'de>,
     {
         let s: &str = Deserialize::deserialize(deserializer)?;
-        Ok(ColumnName::try_from(s).map_err(|e| de::Error::custom(e))?)
+        Ok(ColumnName::try_from(s).map_err(de::Error::custom)?)
     }
 }
 

--- a/dbcrossbarlib/src/drivers/bigquery_shared/table.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/table.rs
@@ -1,7 +1,6 @@
 //! Table-related support for BigQuery.
 
 use itertools::Itertools;
-use serde_json;
 use std::{
     collections::{HashMap, HashSet},
     convert::TryFrom,

--- a/dbcrossbarlib/src/drivers/csv/mod.rs
+++ b/dbcrossbarlib/src/drivers/csv/mod.rs
@@ -1,6 +1,5 @@
 //! Driver for working with CSV files.
 
-use csv;
 use std::{ffi::OsStr, fmt, path::PathBuf, str::FromStr};
 use tokio::{
     fs,

--- a/dbcrossbarlib/src/drivers/postgres/csv_to_binary/mod.rs
+++ b/dbcrossbarlib/src/drivers/postgres/csv_to_binary/mod.rs
@@ -8,11 +8,8 @@
 //! - https://github.com/sfackler/rust-postgres/blob/master/postgres-protocol/src/types.rs Rust implementations.
 
 use byteorder::{NetworkEndian as NE, WriteBytesExt};
-use cast;
 use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
-use csv;
 use geo_types::Geometry;
-use hex;
 use serde_json::Value;
 use std::{
     io::{self, prelude::*},

--- a/dbcrossbarlib/src/from_csv_cell.rs
+++ b/dbcrossbarlib/src/from_csv_cell.rs
@@ -5,7 +5,6 @@ use geo_types::Geometry;
 use geojson::GeoJson;
 use lazy_static::lazy_static;
 use regex::Regex;
-use serde_json;
 use std::convert::TryInto;
 use uuid::Uuid;
 

--- a/dbcrossbarlib/src/from_json_value.rs
+++ b/dbcrossbarlib/src/from_json_value.rs
@@ -1,6 +1,5 @@
 //! Construct various types from parsed JSON values.
 
-use cast;
 use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, Utc};
 use geo_types::Geometry;
 use serde_json::Value;

--- a/dbcrossbarlib/src/lib.rs
+++ b/dbcrossbarlib/src/lib.rs
@@ -17,6 +17,7 @@ use std::result;
 pub(crate) mod args;
 pub(crate) mod clouds;
 pub(crate) mod concat;
+pub mod config;
 pub(crate) mod context;
 pub(crate) mod credentials;
 pub(crate) mod csv_stream;

--- a/dbcrossbarlib/src/lib.rs
+++ b/dbcrossbarlib/src/lib.rs
@@ -4,8 +4,6 @@
 //! module, which defines a portable SQL schema.
 
 #![warn(missing_docs, unused_extern_crates, clippy::all)]
-// Work around clippy false positives.
-#![allow(clippy::redundant_closure, clippy::needless_lifetimes)]
 
 // We keep one `macro_use` here, because `diesel`'s macros do not yet play
 // nicely with the new Rust 2018 macro importing features.

--- a/dbcrossbarlib/src/rechunk.rs
+++ b/dbcrossbarlib/src/rechunk.rs
@@ -1,6 +1,5 @@
 //! Given a stream of streams CSV data, rechunk the stream sizes.
 
-use csv;
 use futures::executor::block_on;
 use std::{cell::Cell, cmp::min, io, rc::Rc};
 use tokio::sync::mpsc;

--- a/dbcrossbarlib/src/schema.rs
+++ b/dbcrossbarlib/src/schema.rs
@@ -182,8 +182,6 @@ fn data_type_serialization_examples() {
 
 #[test]
 fn data_type_roundtrip() {
-    use serde_json;
-
     let data_types = vec![
         DataType::Array(Box::new(DataType::Text)),
         DataType::Bool,

--- a/dbcrossbarlib/src/temporary_storage.rs
+++ b/dbcrossbarlib/src/temporary_storage.rs
@@ -4,6 +4,9 @@ use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 use std::iter;
 
+use crate::common::*;
+use crate::config::Configuration;
+
 /// Provides different types of temporary storage.
 #[derive(Clone, Debug)]
 pub struct TemporaryStorage {
@@ -17,6 +20,16 @@ impl TemporaryStorage {
     /// `bigquery:project:dataset`.
     pub fn new(locations: Vec<String>) -> Self {
         TemporaryStorage { locations }
+    }
+
+    /// Like `new`, but also use temporaries from `config`.
+    pub fn with_config(
+        mut locations: Vec<String>,
+        config: &Configuration,
+    ) -> Result<Self> {
+        // These go _after_, so that they can be overridden by values in `locations`.
+        locations.extend(config.temporaries()?);
+        Ok(TemporaryStorage { locations })
     }
 
     /// Find a location with the specified scheme.

--- a/dbcrossbarlib/src/tokio_glue.rs
+++ b/dbcrossbarlib/src/tokio_glue.rs
@@ -339,7 +339,7 @@ where
 
 /// Run a synchronous function `f` in a background worker thread and return its
 /// value.
-pub(crate) async fn spawn_blocking<F, T>(f: F) -> Result<T>
+pub async fn spawn_blocking<F, T>(f: F) -> Result<T>
 where
     F: (FnOnce() -> Result<T>) + Send + 'static,
     T: Send + 'static,

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -7,6 +7,7 @@
 - [How it works](./how.md)
   - [CSV interchange format](./csv_interchange.md)
   - [Portable table schema](./schema.md)
+- [Configuration](./config.md)
 - [Commands](./commands.md)
   - [`cp`: Copying tables](./cp.md)
   - [`count`: Counting records](./count.md)

--- a/guide/src/config.md
+++ b/guide/src/config.md
@@ -1,0 +1,21 @@
+# Configuring `dbcrossbar`
+
+`dbcrossbar` can read information from a configuration directory. By default, this can be found at:
+
+- Linux: `~/.config`
+- MacOS: `~/Library/Preferences`
+
+To override this default location, you can set `DBCROSSBAR_CONFIG_DIR` to point to an alternate configuration directory.
+
+If a file `dbcrossbar.toml` appears in this directory, `dbcrossbar` will read its configuration from that file. Other files may be placed in this directory, including certain local credential files.
+
+## Modifying the configuration file
+
+You can modify the `dbcrossbar.toml` file from the command line using the `config` subcommand. For example:
+
+```sh
+dbcrossbar config add temporary s3://example/temp/
+dbcrossbar config rm temporary s3://example/temp/
+```
+
+Using `config add temporary` allows you to specify default values for `--temporary` flags. You can still override specific defaults by passing `--temporary` to commands that use it.

--- a/guide/src/examples/my_table_cp_to_bigquery.sh
+++ b/guide/src/examples/my_table_cp_to_bigquery.sh
@@ -1,6 +1,6 @@
+dbcrossbar config add temporary gs://$GS_TEMP_BUCKET
+dbcrossbar config add temporary bigquery:$GCLOUD_PROJECT:temp_dataset
 dbcrossbar cp \
     --if-exists=upsert-on:id \
-    --temporary=gs://$GS_TEMP_BUCKET \
-    --temporary=bigquery:$GCLOUD_PROJECT:temp_dataset \
     'postgres://postgres@127.0.0.1:5432/postgres#my_table' \
     bigquery:$GCLOUD_PROJECT:my_dataset.my_table

--- a/guide/src/gs.md
+++ b/guide/src/gs.md
@@ -21,8 +21,10 @@ At this point, we do not support single-file output to a cloud bucket. This is r
 
 **0.4.x and later:** You can authenticate using either a client secret or a service key, which you can create using the [console credentials page](https://console.cloud.google.com/apis/credentials).
 
-- Client secrets can be stored in `~/.dbcrossbar/config/gcloud_client_secret.json` or in `GCLOUD_CLIENT_SECRET`. These are strongly recommended for interactive use.
-- Service account keys can be stored in `~/.dbcrossbar/config/gcloud_service_account_key.json` or in `GCLOUD_SERVICE_ACCOUNT_KEY`. These are recommended for server and container use.
+- Client secrets can be stored in `$DBCROSSBAR_CONFIG_DIR/gcloud_client_secret.json` or in `GCLOUD_CLIENT_SECRET`. These are strongly recommended for interactive use.
+- Service account keys can be stored in `$DBCROSSBAR_CONFIG_DIR/gcloud_service_account_key.json` or in `GCLOUD_SERVICE_ACCOUNT_KEY`. These are recommended for server and container use.
+
+For more information on `DBCROSSBAR_CONFIG_DIR`, see [Configuration](./config.html).
 
 For a service account, you can use the following permissions:
 

--- a/guide/src/intro.md
+++ b/guide/src/intro.md
@@ -64,7 +64,7 @@ If we want to use this data to update an existing table in BigQuery, we can upse
 {{#include examples/my_table_cp_to_bigquery.sh}}
 ```
 
-This will stream the data out of PostgreSQL, upload it to `$GS_TEMP_BUCKET`, import it into a temporary BigQuery table, and run an appropriate `MERGE` command.
+This will stream the data out of PostgreSQL, upload it to `$GS_TEMP_BUCKET`, import it into a temporary BigQuery table, and run an appropriate `MERGE` command. The `config add temporary` commands tell `dbcrossbar` what cloud bucket and BigQuery dataset should be used for temporary files and tables, respectively.
 
 Notice that we don't need to specify `--schema`, because `dbcrossbar` will automatically translate the PostgreSQL column types to corresponding BigQuery types. The `--temporary` arguments specify what bucket to use for loading the CSV files, and what BigQuery data set to use for the temporary table used as input to the `MERGE`.
 


### PR DESCRIPTION
For now, this allows you to specify permanent `--temporary`
arguments:

    dbcrossbar config add temporary s3://example/temp/
    dbcrossbar config rm temporary s3://example/temp/

This file lives in `$DBCROSSBAR_CONFIG_DIR/dbcrossbar.toml`,
and `$DBCROSSBAR_CONFIG_DIR` defaults to a platform-appropriate
location.

The actual config-editing code uses `toml_edit`, which allows
us to programmatically edit a TOML file without losing existing
comments and whitespace. Unfortunately, this requires some
fairly verbose code, because it's not as convenient as `serde`.

I've deliberately kept the configuration `Key` type opaque,
because I plan to support driver- and host-specific config keys,
and I don't want to break the library API when I add them.

This doesn't implement all of #116, but it's probably most of what we need for v0.4.0-beta.1.