### PR TITLE
dbcrossbar-ts: Specify schemas with a subset of TypeScript

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "codespan-reporting"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "combine"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,6 +494,7 @@ dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cast 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "codespan-reporting 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -501,6 +511,7 @@ dependencies = [
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "main_error 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "peg 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -521,6 +532,7 @@ dependencies = [
  "strum 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum_macros 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-postgres 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml_edit 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1070,6 +1082,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "main_error"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "matches"
@@ -2561,6 +2578,7 @@ dependencies = [
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cli_test_dir 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "2bc63338a59538d4f4b767dfb6082e4d26736aadb5100894b76039a04d6ad519"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum codespan-reporting 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d5680df8512a0e825b9edc41b619ec88b367644d394b4d862a04b4d6387c65da"
 "checksum combine 3.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
 "checksum common_failures 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c84afb517ac0988b7e049e06c51511716f80d0f0233972fca666d3f14f80d8fb"
 "checksum constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
@@ -2644,6 +2662,7 @@ dependencies = [
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum lock_api 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "79b2de95ecb4691949fea4716ca53cdbcfccb2c612e19644a8bad05edcf9f47b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+"checksum main_error 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3516df0fb44d98fe6d6e859d224adfb7b6686447937e5b96308d6061595eed04"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum md5 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"

--- a/dbcrossbar/fixtures/dbcrossbar_ts/shapes.json
+++ b/dbcrossbar/fixtures/dbcrossbar_ts/shapes.json
@@ -1,0 +1,25 @@
+{
+    "name": "Shape",
+    "columns": [
+        {
+            "name": "points",
+            "is_nullable": false,
+            "data_type": {
+                "array": {
+                    "struct": [
+                        {
+                            "name": "x",
+                            "is_nullable": false,
+                            "data_type": "float64"
+                        },
+                        {
+                            "name": "y",
+                            "is_nullable": false,
+                            "data_type": "float64"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/dbcrossbar/fixtures/dbcrossbar_ts/shapes.ts
+++ b/dbcrossbar/fixtures/dbcrossbar_ts/shapes.ts
@@ -1,0 +1,8 @@
+interface Shape {
+    points: Point[],
+};
+
+interface Point {
+    x: number,
+    y: number,
+};

--- a/dbcrossbar/tests/cli/conv.rs
+++ b/dbcrossbar/tests/cli/conv.rs
@@ -99,3 +99,25 @@ fn conv_bq_schema_to_pg_sql() {
     let expected = fs::read_to_string(&expected_sql).unwrap();
     testdir.expect_file_contents("output.sql", &expected);
 }
+
+#[test]
+fn conv_ts_to_portable() {
+    let testdir = TestDir::new("dbcrossbar", "conv_ts_to_portable");
+    let input_ts = testdir.src_path("fixtures/dbcrossbar_ts/shapes.ts");
+    let output_json = testdir.path("output.json");
+    let expected_json = testdir.src_path("fixtures/dbcrossbar_ts/shapes.json");
+    testdir
+        .cmd()
+        .args(&[
+            "conv",
+            &format!("dbcrossbar-ts:{}#Shape", input_ts.display()),
+            &format!("dbcrossbar-schema:{}", output_json.display()),
+        ])
+        .expect_success();
+    let output = fs::read_to_string(&output_json).unwrap();
+    let expected = fs::read_to_string(&expected_json).unwrap();
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&output).unwrap(),
+        serde_json::from_str::<serde_json::Value>(&expected).unwrap(),
+    );
+}

--- a/dbcrossbarlib/Cargo.toml
+++ b/dbcrossbarlib/Cargo.toml
@@ -14,6 +14,7 @@ repository = "https://github.com/dbcrossbar/dbcrossbar"
 documentation = "https://docs.rs/dbcrossbarlib/"
 
 [dev-dependencies]
+main_error = "0.1.0"
 slog-async = "2.3.0"
 slog-envlogger = "2.1.0"
 slog-term = "2.4.0"
@@ -26,6 +27,7 @@ byteorder = "1.3.1"
 bytes = "0.5.3"
 cast = "0.2.3"
 chrono = "0.4.6"
+codespan-reporting = "0.9.3"
 csv = "1.0.5"
 diesel = { version = "1.3.3", features = ["postgres"] }
 dirs = "2.0.2"
@@ -60,6 +62,7 @@ slog = "2.4.1"
 strum = "0.18.0"
 strum_macros = "0.18.0"
 tempdir = "0.3.7"
+termcolor = "1.1.0"
 tokio = { version = "0.2.6", features = ["fs", "io-std", "io-util", "process", "stream", "sync", "time"] }
 toml_edit = "0.1.5"
 url = "2.1.0"

--- a/dbcrossbarlib/src/drivers/dbcrossbar_schema/mod.rs
+++ b/dbcrossbarlib/src/drivers/dbcrossbar_schema/mod.rs
@@ -4,7 +4,7 @@ use std::{fmt, str::FromStr};
 
 use crate::common::*;
 
-/// A JSON file containing BigQuery table schema.
+/// A JSON file containing a `dbcrossbar` native schema.
 #[derive(Clone, Debug)]
 pub struct DbcrossbarSchemaLocator {
     path: PathOrStdio,

--- a/dbcrossbarlib/src/drivers/dbcrossbar_ts/ast.rs
+++ b/dbcrossbarlib/src/drivers/dbcrossbar_ts/ast.rs
@@ -1,0 +1,474 @@
+//! Support for schemas specifd using a subset of TypeScript.
+
+use std::{collections::HashMap, fmt, ops::Range, sync::Arc};
+
+use crate::common::*;
+use crate::parse_error::{Annotation, AnnotationType, Location, ParseError};
+use crate::schema::{Column, DataType, StructField, Table};
+
+/// We represent a span in our source code using a Rust range.
+type Span = Range<usize>;
+
+/// A node in our abstract syntax tree.
+pub(crate) trait Node: fmt::Debug {
+    /// The soure span corresponding to this node.
+    fn span(&self) -> Span;
+}
+
+/// Interface for types which can be converted to `DataType`.
+pub(crate) trait ToDataType {
+    /// Convert this type to a `DataType`, given
+    fn to_data_type(&self, source_file: &SourceFile) -> Result<DataType, ParseError>;
+}
+
+/// A TypeScript source file containing a limited set of type definitions.
+pub(crate) struct SourceFile {
+    /// The name of our input file.
+    file_name: String,
+    /// Our original input data. We manage this using an atomic reference count,
+    /// so that we can share ownership with `ParseError`.
+    file_string: Arc<String>,
+    /// The type definitions found in this file.
+    definitions: HashMap<String, Definition>,
+}
+
+impl SourceFile {
+    /// Parse a source file from a `&str`.
+    pub(crate) fn parse(
+        file_name: String,
+        file_string: String,
+    ) -> Result<Self, ParseError> {
+        let file_string = Arc::new(file_string);
+        let definition_vec = typescript_grammar::definitions(file_string.as_ref())
+            .map_err(|err| {
+                ParseError::from_file_string(
+                    file_name.clone(),
+                    file_string.clone(),
+                    vec![Annotation {
+                        ty: AnnotationType::Primary,
+                        location: Location::Position(err.location.offset),
+                        message: format!("expected {}", err.expected),
+                    }],
+                    format!("error parsing {}", file_name),
+                )
+            })?;
+        let mut definitions = HashMap::with_capacity(definition_vec.len());
+        for d in definition_vec {
+            let name = d.name().to_owned();
+            if let Some(existing) = definitions.insert(name.as_str().to_owned(), d) {
+                return Err(ParseError::from_file_string(
+                    file_name,
+                    file_string,
+                    vec![
+                        Annotation {
+                            ty: AnnotationType::Secondary,
+                            location: Location::Range(existing.name().span()),
+                            message: "existing definition here".to_owned(),
+                        },
+                        Annotation {
+                            ty: AnnotationType::Primary,
+                            location: Location::Range(name.span()),
+                            message: "duplicate definition here".to_owned(),
+                        },
+                    ],
+                    format!("duplicate definition of {}", name),
+                ));
+            }
+        }
+        Ok(SourceFile {
+            file_name,
+            file_string,
+            definitions,
+        })
+    }
+
+    /// Look up a definition in this source file.
+    pub(crate) fn definition<'a>(&'a self, name: &str) -> Result<&'a Definition> {
+        self.definitions.get(name).ok_or_else(|| {
+            format_err!("type `{}` is not defined in {}", name, self.file_name)
+        })
+    }
+
+    /// Look up a definition in the source file using an identifier.
+    fn definition_for_identifier<'a>(
+        &'a self,
+        id: &Identifier,
+    ) -> Result<&'a Definition, ParseError> {
+        self.definitions.get(id.as_str()).ok_or_else(|| {
+            ParseError::from_file_string(
+                self.file_name.clone(),
+                self.file_string.clone(),
+                vec![Annotation {
+                    ty: AnnotationType::Primary,
+                    location: Location::Range(id.span()),
+                    message: "cannot find the definition of this type".to_string(),
+                }],
+                format!("cannot find definition of {}", id),
+            )
+        })
+    }
+
+    /// Look up a definition and recursively convert it to a portable [`Table`].
+    pub(crate) fn definition_to_table(&self, name: &str) -> Result<Table> {
+        let def = self.definition(name)?;
+        match def.to_data_type(self)? {
+            DataType::Struct(fields) => {
+                Ok(Table {
+                    name: name.to_owned(),
+                    columns: fields.into_iter().map(|f| {
+                        Column {
+                            name: f.name,
+                            is_nullable: f.is_nullable,
+                            data_type: f.data_type,
+                            comment: None, }
+                    }).collect(),
+                })
+            }
+            _ => Err(ParseError::from_file_string(
+                self.file_name.clone(),
+                self.file_string.clone(),
+                vec![Annotation {
+                    ty: AnnotationType::Primary,
+                    location: Location::Range(def.name().span()),
+                    message: "expected an interface type".to_string(),
+                }],
+                format!("cannot convert {} to a table schema because it is not an interface", name),
+            ).into()),
+        }
+    }
+
+    /// Look up an identifier and recursively convert it to a [`DataType`].
+    pub(crate) fn identifier_to_data_type(
+        &self,
+        id: &Identifier,
+    ) -> Result<DataType, ParseError> {
+        let def = self.definition_for_identifier(id)?;
+        def.to_data_type(self)
+    }
+}
+
+/// A type definition.
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum Definition {
+    /// An interface definition.
+    Interface(Interface),
+    /// A type alias.
+    TypeAlias(Identifier, Type),
+}
+
+impl Definition {
+    pub(crate) fn name(&self) -> &Identifier {
+        match self {
+            Definition::Interface(iface) => &iface.name,
+            Definition::TypeAlias(name, _) => name,
+        }
+    }
+}
+
+impl ToDataType for Definition {
+    fn to_data_type(&self, source_file: &SourceFile) -> Result<DataType, ParseError> {
+        match self {
+            Definition::Interface(iface) => iface.to_data_type(source_file),
+            Definition::TypeAlias(_, ty) => ty.to_data_type(source_file),
+        }
+    }
+}
+
+/// An `interface` type.
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct Interface {
+    name: Identifier,
+    fields: Vec<Field>,
+}
+
+impl ToDataType for Interface {
+    fn to_data_type(&self, source_file: &SourceFile) -> Result<DataType, ParseError> {
+        let fields = self
+            .fields
+            .iter()
+            .map(|f| {
+                let (optional, ty) = f.ty.to_possibly_optional_type();
+                Ok(StructField {
+                    name: f.name.as_str().to_owned(),
+                    is_nullable: f.optional | optional,
+                    data_type: ty.to_data_type(source_file)?,
+                })
+            })
+            .collect::<Result<_, _>>()?;
+        Ok(DataType::Struct(fields))
+    }
+}
+
+/// A field in an interface (or other struct-like type).
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct Field {
+    name: Identifier,
+    optional: bool,
+    ty: Type,
+}
+
+/// A TypeScript type, without any span information.
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum TypeDetails {
+    /// Any value.
+    Any,
+    //// An array type.
+    Array(Box<Type>),
+    /// A true or false value.
+    Boolean,
+    /// The null value.
+    Null,
+    /// A 64-bit floating point number.
+    Number,
+    /// A reference to another type by name.
+    Ref(Identifier),
+    /// A string.
+    String,
+    /// A type union (made with `|`).
+    Union(Box<Type>, Box<Type>),
+}
+
+/// A TypeScript type.
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct Type {
+    span: Span,
+    details: TypeDetails,
+}
+
+impl Type {
+    /// Is this type equivalent to an SQL NULL?
+    fn is_sql_null(&self) -> bool {
+        match &self.details {
+            TypeDetails::Null => true,
+            _ => false,
+        }
+    }
+
+    /// If this type is `x | null` or `null | x`, return `(true, x)`. Otherwise,
+    /// return `(false, self)`.
+    fn to_possibly_optional_type(&self) -> (bool, &Type) {
+        match &self.details {
+            TypeDetails::Union(t1, t2) if t2.is_sql_null() => (true, t1),
+            TypeDetails::Union(t1, t2) if t1.is_sql_null() => (true, t2),
+            _ => (false, self),
+        }
+    }
+}
+
+impl ToDataType for Type {
+    fn to_data_type(&self, source_file: &SourceFile) -> Result<DataType, ParseError> {
+        match &self.details {
+            TypeDetails::Any => Ok(DataType::Json),
+
+            TypeDetails::Array(elem) => elem
+                .to_data_type(source_file)
+                .map(|ty| DataType::Array(Box::new(ty))),
+
+            TypeDetails::Boolean => Ok(DataType::Bool),
+
+            TypeDetails::Null => Err(ParseError::from_file_string(
+                source_file.file_name.clone(),
+                source_file.file_string.clone(),
+                vec![Annotation {
+                    ty: AnnotationType::Primary,
+                    location: Location::Range(self.span.clone()),
+                    message: "null type found here".to_string(),
+                }],
+                "cannot convert `null` type to dbcrossbar type".to_owned(),
+            )),
+
+            TypeDetails::Number => Ok(DataType::Float64),
+
+            TypeDetails::Ref(id) => source_file.identifier_to_data_type(&id),
+
+            TypeDetails::String => Ok(DataType::Text),
+
+            TypeDetails::Union(_, _) => Err(ParseError::from_file_string(
+                source_file.file_name.clone(),
+                source_file.file_string.clone(),
+                vec![Annotation {
+                    ty: AnnotationType::Primary,
+                    location: Location::Range(self.span.clone()),
+                    message: "union type found here".to_string(),
+                }],
+                "cannot convert union type to dbcrossbar type".to_owned(),
+            )),
+        }
+    }
+}
+
+/// A TypeScript identifier.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct Identifier(Span, String);
+
+impl Identifier {
+    /// The underlying string for this identifier.
+    fn as_str(&self) -> &str {
+        &self.1
+    }
+}
+
+impl fmt::Display for Identifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "`{}`", self.1)
+    }
+}
+
+impl Node for Identifier {
+    fn span(&self) -> Span {
+        self.0.clone()
+    }
+}
+
+peg::parser! {
+    grammar typescript_grammar() for str {
+        pub(crate) rule definitions() -> Vec<Definition>
+            = ws()? definitions:(definition() ** (ws()?)) ws()? {
+                definitions
+            }
+
+        rule definition() -> Definition
+            = iface:interface() { Definition::Interface(iface) }
+            / "type" ws() name:identifier() ws()? "=" ws()? ty:ty() ws()? ";" {
+                Definition::TypeAlias(name, ty)
+            }
+
+        rule interface() -> Interface
+            = "interface" ws() name:identifier() ws()? "{" fields:fields() "}" ws()? ";" {
+                Interface { name, fields }
+            }
+
+        rule fields() -> Vec<Field>
+            = ws()? fields:(field() ** (ws()? "," ws()?)) (ws()? ",")? ws()? { fields }
+
+        rule field() -> Field
+            = name:identifier() optional:optional_mark() ":" ws()? ty:ty() {
+                Field { name, optional, ty }
+            }
+
+        // For optional fields.
+        rule optional_mark() -> bool
+            = ws()? "?" { true }
+            / { false }
+
+        // Type expressions. We parse this using `precedence!`, which parses
+        // prefix, postfix, left-associative and right associative operators
+        // using the "packrat" algorithm, so we don't need to write this rule
+        // out the hard way.
+        //
+        // The lowest-pecedence operators are on top, and the highest on bottom.
+        rule ty() -> Type = precedence! {
+            // This rule is special: it exists to wrap all the other rules in a
+            // `Type` with span information. The `position!()` macro only works
+            // in this rule.
+            s:position!() details:@ e:position!() {
+                Type { span: s..e, details }
+            }
+            --
+            left:(@) ws()? "|" ws()? right:@ {
+                TypeDetails::Union(Box::new(left), Box::new(right))
+            }
+            --
+            elem:@ ws()? "[" ws()? "]" e:position!() {
+                TypeDetails::Array(Box::new(elem))
+            }
+            --
+            "any" { TypeDetails::Any }
+            "string" { TypeDetails::String }
+            "null" { TypeDetails::Null }
+            "number" { TypeDetails::Number }
+            "boolean" { TypeDetails::Boolean }
+            id:identifier() { TypeDetails::Ref(id) }
+        }
+
+        rule identifier() -> Identifier
+            = quiet! {
+                s:position!()
+                id:$(
+                    ['A'..='Z' | 'a'..='z' | '_']
+                    ['A'..='Z' | 'a'..='z' | '_' | '0'..='9']*
+                )
+                e:position!()
+                { Identifier(s..e, id.to_owned()) }
+
+            }
+            / expected!("identifier")
+
+        rule ws() = quiet! { ([' ' | '\t' | '\r' | '\n'] / line_comment())+ }
+
+        rule line_comment() = "//" (!['\n'][_])* ( "\n" / ![_] )
+    }
+}
+
+// Use `main_error` for pretty test output.
+#[test]
+fn parses_typescript_and_converts_to_data_type() -> Result<(), main_error::MainError> {
+    let input = r#"
+interface PriceSet {
+    shop_money: Money,
+    presentement_money: Money,
+};
+    
+interface Money {
+    amount: string, // Currency decimal encoded as string.
+    currency_code: string,
+};
+"#;
+    let source_file = SourceFile::parse("test.ts".to_owned(), input.to_owned())?;
+    assert_eq!(
+        source_file.definition_to_table("PriceSet")?,
+        Table {
+            name: "PriceSet".to_owned(),
+            columns: vec![
+                Column {
+                    name: "shop_money".to_owned(),
+                    is_nullable: false,
+                    data_type: DataType::Struct(vec![
+                        StructField {
+                            name: "amount".to_owned(),
+                            is_nullable: false,
+                            data_type: DataType::Text,
+                        },
+                        StructField {
+                            name: "currency_code".to_owned(),
+                            is_nullable: false,
+                            data_type: DataType::Text,
+                        },
+                    ]),
+                    comment: None,
+                },
+                Column {
+                    name: "presentement_money".to_owned(),
+                    is_nullable: false,
+                    data_type: DataType::Struct(vec![
+                        StructField {
+                            name: "amount".to_owned(),
+                            is_nullable: false,
+                            data_type: DataType::Text,
+                        },
+                        StructField {
+                            name: "currency_code".to_owned(),
+                            is_nullable: false,
+                            data_type: DataType::Text,
+                        },
+                    ]),
+                    comment: None,
+                },
+            ]
+        },
+    );
+
+    Ok(())
+}
+
+// Use `main_error` for pretty test output.
+#[test]
+fn parses_shopify_schema() -> Result<(), main_error::MainError> {
+    let file_string = include_str!("shopify.ts");
+    let source_file =
+        SourceFile::parse("shopify.ts".to_owned(), file_string.to_owned())?;
+    for def in &["Order"] {
+        source_file.definition_to_table(def)?;
+    }
+    Ok(())
+}

--- a/dbcrossbarlib/src/drivers/dbcrossbar_ts/ast.rs
+++ b/dbcrossbarlib/src/drivers/dbcrossbar_ts/ast.rs
@@ -17,7 +17,7 @@ type Span = Range<usize>;
 
 /// A node in our abstract syntax tree.
 pub(crate) trait Node: fmt::Debug {
-    /// The soure span corresponding to this node.
+    /// The source span corresponding to this node.
     fn span(&self) -> Span;
 }
 
@@ -67,14 +67,14 @@ impl SourceFile {
                     file_string,
                     vec![
                         Annotation {
-                            ty: AnnotationType::Secondary,
-                            location: Location::Range(existing.name().span()),
-                            message: "existing definition here".to_owned(),
-                        },
-                        Annotation {
                             ty: AnnotationType::Primary,
                             location: Location::Range(name.span()),
                             message: "duplicate definition here".to_owned(),
+                        },
+                        Annotation {
+                            ty: AnnotationType::Secondary,
+                            location: Location::Range(existing.name().span()),
+                            message: "existing definition here".to_owned(),
                         },
                     ],
                     format!("duplicate definition of {}", name),
@@ -202,14 +202,14 @@ impl ToDataType for Interface {
                     source_file.file_string.clone(),
                     vec![
                         Annotation {
-                            ty: AnnotationType::Secondary,
-                            location: Location::Range(existing.span()),
-                            message: "original definition here".to_owned(),
-                        },
-                        Annotation {
                             ty: AnnotationType::Primary,
                             location: Location::Range(f.name.span()),
                             message: "defined again here".to_owned(),
+                        },
+                        Annotation {
+                            ty: AnnotationType::Secondary,
+                            location: Location::Range(existing.span()),
+                            message: "original definition here".to_owned(),
                         },
                     ],
                     format!("duplicate definition of {} field", f.name),

--- a/dbcrossbarlib/src/drivers/dbcrossbar_ts/ast.rs
+++ b/dbcrossbarlib/src/drivers/dbcrossbar_ts/ast.rs
@@ -422,7 +422,7 @@ peg::parser! {
                 TypeDetails::Union(Box::new(left), Box::new(right))
             }
             --
-            elem:@ ws()? "[" ws()? "]" e:position!() {
+            elem:@ ws()? "[" ws()? "]" {
                 TypeDetails::Array(Box::new(elem))
             }
             --

--- a/dbcrossbarlib/src/drivers/dbcrossbar_ts/mod.rs
+++ b/dbcrossbarlib/src/drivers/dbcrossbar_ts/mod.rs
@@ -1,0 +1,107 @@
+//! Support for `dbcrossbar-ts` locators.
+
+use percent_encoding::percent_decode_str;
+use std::{fmt, path::PathBuf, str::FromStr};
+
+use crate::common::*;
+
+mod ast;
+
+use self::ast::SourceFile;
+
+/// A file containing type definitions written in a subset of TypeScript.
+#[derive(Clone, Debug)]
+pub struct DbcrossbarTsLocator {
+    path: PathOrStdio,
+    fragment: String,
+}
+
+impl fmt::Display for DbcrossbarTsLocator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let encode = |s: &str| s.replace('%', "%25").replace('#', "%23");
+        write!(
+            f,
+            "{}{}#{}",
+            Self::scheme(),
+            encode(&self.path.to_string()),
+            encode(&self.fragment)
+        )
+    }
+}
+
+impl FromStr for DbcrossbarTsLocator {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        if !s.starts_with(Self::scheme()) {
+            return Err(format_err!(
+                "expected {:?} to start with {}",
+                s,
+                Self::scheme()
+            ));
+        }
+        let parts = s[Self::scheme().len()..].splitn(2, '#').collect::<Vec<_>>();
+        if parts.len() != 2 {
+            return Err(format_err!("expected '#' in {:?}", s));
+        }
+        let decode = |idx| {
+            percent_decode_str(parts[idx])
+                .decode_utf8()
+                .with_context(|_| format!("error decoding {:?}", s))
+        };
+        let path = decode(0)?;
+        let fragment = decode(1)?.into_owned();
+        let path = if path == "-" {
+            PathOrStdio::Stdio
+        } else {
+            PathOrStdio::Path(PathBuf::from(path.into_owned()))
+        };
+        Ok(DbcrossbarTsLocator { path, fragment })
+    }
+}
+
+impl Locator for DbcrossbarTsLocator {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self, ctx: Context) -> BoxFuture<Option<Table>> {
+        schema_helper(ctx, self.to_owned()).boxed()
+    }
+}
+
+impl LocatorStatic for DbcrossbarTsLocator {
+    fn scheme() -> &'static str {
+        "dbcrossbar-ts:"
+    }
+
+    fn features() -> Features {
+        Features {
+            locator: LocatorFeatures::Schema.into(),
+            write_schema_if_exists: IfExistsFeatures::no_append(),
+            source_args: EnumSet::empty(),
+            dest_args: EnumSet::empty(),
+            dest_if_exists: EnumSet::empty(),
+            _placeholder: (),
+        }
+    }
+}
+
+/// Implementation of `schema`, but as a real `async` function.
+async fn schema_helper(
+    _ctx: Context,
+    source: DbcrossbarTsLocator,
+) -> Result<Option<Table>> {
+    // Read our input.
+    let input = source.path.open_async().await?;
+    let data = async_read_to_end(input)
+        .await
+        .with_context(|_| format!("error reading {}", source.path))?;
+    let data = String::from_utf8(data)
+        .with_context(|_| format!("found non-UTF-8 data in {}", source.path))?;
+
+    // Parse it as a TypeScript file.
+    let source_file = SourceFile::parse(source.path.to_string(), data)?;
+    let table = source_file.definition_to_table(&source.fragment)?;
+    Ok(Some(table))
+}

--- a/dbcrossbarlib/src/drivers/dbcrossbar_ts/shopify.ts
+++ b/dbcrossbarlib/src/drivers/dbcrossbar_ts/shopify.ts
@@ -69,7 +69,7 @@ interface Order {
     updated_at: string,
     user_id: number,
     order_status_url: string,
-};
+}
 
 interface Address {
     address1: string,
@@ -87,7 +87,7 @@ interface Address {
     country_code: string,
     latitude: string,
     longitude: string,
-};
+}
 
 interface ClientDetails {
     accepts_language: string,
@@ -96,7 +96,7 @@ interface ClientDetails {
     browser_width: number,
     session_hash: string,
     user_agent: string,
-};
+}
 
 // https://shopify.dev/docs/admin-api/rest/reference/customers/customer?api[version]=2020-04
 interface Customer {
@@ -125,7 +125,7 @@ interface Customer {
     total_spent: Decimal,
     updated_at: string,
     verified_email: boolean,
-};
+}
 
 interface DiscountApplication {
     type: string,
@@ -135,13 +135,13 @@ interface DiscountApplication {
     allocation_method: string,
     target_selection: string,
     target_type: string,
-};
+}
 
 interface DiscountCode {
     code: string,
     amount: Decimal,
     type: string,
-};
+}
 
 // https://shopify.dev/docs/admin-api/rest/reference/shipping-and-fulfillment/fulfillment?api[version]=2020-04
 interface Fulfillment {
@@ -161,7 +161,7 @@ interface Fulfillment {
     tracking_urls: string[],
     updated_at: string,
     variant_inventory_management: string,
-};
+}
 
 interface LineItem {
     fulfillable_quantity: number,
@@ -190,40 +190,40 @@ interface LineItem {
     duties: Duty[],
     tip_payment_gateway?: string,
     tip_payment_method?: string,
-};
+}
 
 interface Receipt {
     testcase: boolean,
     authorization: string,
-};
+}
 
 interface PriceSet {
     shop_money: Money,
     presentement_money: Money,
-};
+}
 
 interface Money {
     amount: Decimal,
     currency_code: string,
-};
+}
 
 interface Property {
     name: string,
     value: string, // Well, we hope that's the only possibility.
-};
+}
 
 interface TaxLine {
     title: string,
     price: string,
     price_set: PriceSet,
     rate: number,
-};
+}
 
 interface DiscountAllocation {
     amount: Decimal,
     discount_application_index: number,
     amount_set: PriceSet,
-};
+}
 
 interface Duty {
     id: string,
@@ -233,7 +233,7 @@ interface Duty {
     presentment_money: Money,
     tax_lines: TaxLine[],
     admin_graphql_api_id: string,
-};
+}
 
 interface PaymentDetails {
     avs_result_code: string,
@@ -241,7 +241,7 @@ interface PaymentDetails {
     cvv_result_code: string,
     credit_card_number: string,
     credit_card_company: string,
-};
+}
 
 // https://shopify.dev/docs/admin-api/rest/reference/orders/refund?api[version]=2020-04
 interface Refund {
@@ -255,7 +255,7 @@ interface Refund {
     restock: boolean,
     transactions: Transaction[],
     user_id: number,
-};
+}
 
 interface OrderAdjustment {
     id: number,
@@ -267,7 +267,7 @@ interface OrderAdjustment {
     reason: string,
     amount_set: PriceSet,
     tax_amount_set: PriceSet,
-};
+}
 
 interface RefundLineItem {
     id: number,
@@ -280,7 +280,7 @@ interface RefundLineItem {
     total_tax: number,
     subtotal_set: PriceSet,
     total_tax_set: PriceSet,
-};
+}
 
 // https://shopify.dev/donullcs/admin-api/rest/reference/orders/transaction?api[version]=2020-04
 interface Transaction {
@@ -305,7 +305,7 @@ interface Transaction {
     test: boolean,
     user_id: number,
     currency_exchange_adjustment: CurrencyExchangeAdjustment,
-};
+}
 
 interface CurrencyExchangeAdjustment {
     id: number,
@@ -313,7 +313,7 @@ interface CurrencyExchangeAdjustment {
     original_amount: Decimal,
     final_amount: Decimal,
     currency: string,
-};
+}
 
 interface ShippingLine {
     code: string,
@@ -326,4 +326,4 @@ interface ShippingLine {
     tax_lines: TaxLine[],
     carrier_identifier: string,
     requested_fulfillment_service_id: string,
-};
+}

--- a/dbcrossbarlib/src/drivers/dbcrossbar_ts/shopify.ts
+++ b/dbcrossbarlib/src/drivers/dbcrossbar_ts/shopify.ts
@@ -1,0 +1,329 @@
+// This is a Shopify REST schema that we built by reading the docs.
+
+// A decimal value represented as a string for accuracy.
+type Decimal = string;
+
+// A type that we still need to look up.
+//type TODO = string;
+
+// https://shopify.dev/docs/admin-api/rest/reference/orders/order?api[version]=2020-04
+interface Order {
+    app_id: number,
+    billing_address: Address,
+    browser_ip: string,
+    buyer_accepts_marketing: string,
+    cancel_reason: string,
+    cancelled_at: string, // ISO 8601
+    cart_token: string,
+    client_details: ClientDetails,
+    closed_at: string,
+    created_at: string,
+    currency: string,
+    current_total_duties_set: string,
+    customer: Customer,
+    customer_local: string,
+    discount_applications: DiscountApplication[],
+    discount_codes: DiscountCode[],
+    email: string,
+    financial_status: string,
+    fulfillments: Fulfillment[],
+    fulfillment_status: string,
+    gateway: string, // Deprecated.
+    id: string,
+    landing_site: string,
+    line_items: LineItem[],
+    location_id: number,
+    name: string,
+    note: string,
+    note_attributes: Property[],
+    number: number,
+    order_number: number,
+    original_total_duties_set: PriceSet,
+    payment_details: PaymentDetails, // Deprecated.
+    payment_gateway_names: string[],
+    phone: string,
+    presentment_currency: string,
+    processed_at: string,
+    processing_method: string,
+    referring_site: string,
+    refunds: Refund[],
+    shipping_address: Address, // Optional.
+    shipping_lines: ShippingLine[],
+    source_name: string,
+    subtotal_price: number,
+    subtotal_price_set: PriceSet,
+    tags: string, // Comma-separated.
+    tax_lines: TaxLine[], // May not have `price_set` here?
+    taxes_included: boolean,
+    test: boolean,
+    token: string,
+    total_discounts: Decimal,
+    total_discounts_set: PriceSet,
+    total_line_items_price: Decimal,
+    total_line_items_price_set: PriceSet,
+    total_price_set: PriceSet,
+    total_tax: Decimal,
+    total_tax_set: PriceSet,
+    total_tip_received: Decimal,
+    total_weight: number,
+    updated_at: string,
+    user_id: number,
+    order_status_url: string,
+};
+
+interface Address {
+    address1: string,
+    address2: string,
+    city: string,
+    company: string,
+    country: string,
+    first_name: string,
+    last_name: string,
+    phone: string,
+    province: string,
+    zip: string,
+    name: string,
+    province_code: string,
+    country_code: string,
+    latitude: string,
+    longitude: string,
+};
+
+interface ClientDetails {
+    accepts_language: string,
+    browser_height: number,
+    browser_ip: string,
+    browser_width: number,
+    session_hash: string,
+    user_agent: string,
+};
+
+// https://shopify.dev/docs/admin-api/rest/reference/customers/customer?api[version]=2020-04
+interface Customer {
+    accepts_marketing: boolean,
+    accepts_marketing_updated_at: string,
+    addresses: Address[],
+    admin_graphql_api_id: string,
+    created_at: string,
+    currency: string,
+    default_address: Address,
+    email: string,
+    first_name: string,
+    id: number,
+    last_name: string,
+    last_order_id: number,
+    last_order_name: string,
+    // metafield,
+    multipass_identifier: string | null,
+    note: string,
+    orders_count: string, // String as integer.
+    phone: string,
+    state: string, // "disabled" is a valid value.
+    tags: string,
+    tax_exempt: boolean,
+    tax_exemptions: string[],
+    total_spent: Decimal,
+    updated_at: string,
+    verified_email: boolean,
+};
+
+interface DiscountApplication {
+    type: string,
+    description: string,
+    value: Decimal,
+    value_type: string,
+    allocation_method: string,
+    target_selection: string,
+    target_type: string,
+};
+
+interface DiscountCode {
+    code: string,
+    amount: Decimal,
+    type: string,
+};
+
+// https://shopify.dev/docs/admin-api/rest/reference/shipping-and-fulfillment/fulfillment?api[version]=2020-04
+interface Fulfillment {
+    created_at: string,
+    id: number,
+    line_items: LineItem[],
+    location_id: number,
+    name: string,
+    notify_customer: boolean,
+    order_id: string,
+    receipt: Receipt,
+    service: string,
+    shipment_status: string,
+    status: string,
+    tracking_company: string,
+    tracking_numbers: string[],
+    tracking_urls: string[],
+    updated_at: string,
+    variant_inventory_management: string,
+};
+
+interface LineItem {
+    fulfillable_quantity: number,
+    fulfillment_service: string,
+    fulfillment_status: string,
+    grams: number,
+    id: number,
+    price: Decimal,
+    product_id: number,
+    quantity: number,
+    requires_shipping: boolean,
+    sku: string,
+    title: string,
+    variant_id: number,
+    variant_title: string,
+    vendor: string,
+    name: string,
+    gift_card: boolean,
+    price_set: PriceSet,
+    properties: Property[],
+    taxable: boolean,
+    tax_lines: TaxLine[],
+    total_discount: Decimal,
+    total_discount_set: PriceSet,
+    discount_allocations: DiscountAllocation[],
+    duties: Duty[],
+    tip_payment_gateway?: string,
+    tip_payment_method?: string,
+};
+
+interface Receipt {
+    testcase: boolean,
+    authorization: string,
+};
+
+interface PriceSet {
+    shop_money: Money,
+    presentement_money: Money,
+};
+
+interface Money {
+    amount: Decimal,
+    currency_code: string,
+};
+
+interface Property {
+    name: string,
+    value: string, // Well, we hope that's the only possibility.
+};
+
+interface TaxLine {
+    title: string,
+    price: string,
+    price_set: PriceSet,
+    rate: number,
+};
+
+interface DiscountAllocation {
+    amount: Decimal,
+    discount_application_index: number,
+    amount_set: PriceSet,
+};
+
+interface Duty {
+    id: string,
+    harmonized_system_code: string,
+    country_code_of_origin: string,
+    shop_money: Money,
+    presentment_money: Money,
+    tax_lines: TaxLine[],
+    admin_graphql_api_id: string,
+};
+
+interface PaymentDetails {
+    avs_result_code: string,
+    credit_card_bin: string,
+    cvv_result_code: string,
+    credit_card_number: string,
+    credit_card_company: string,
+};
+
+// https://shopify.dev/docs/admin-api/rest/reference/orders/refund?api[version]=2020-04
+interface Refund {
+    created_at: string,
+    duties: Duty[],
+    id: number,
+    note: string,
+    order_adjustments: OrderAdjustment[],
+    processed_at: string,
+    refund_line_items: RefundLineItem[],
+    restock: boolean,
+    transactions: Transaction[],
+    user_id: number,
+};
+
+interface OrderAdjustment {
+    id: number,
+    order_id: number,
+    refund_id: number,
+    amount: Decimal,
+    tax_amount: Decimal,
+    kind: string,
+    reason: string,
+    amount_set: PriceSet,
+    tax_amount_set: PriceSet,
+};
+
+interface RefundLineItem {
+    id: number,
+    line_item: LineItem,
+    line_item_id: number,
+    quantity: number,
+    location_id: number,
+    restock_type: string,
+    subtotal: number,
+    total_tax: number,
+    subtotal_set: PriceSet,
+    total_tax_set: PriceSet,
+};
+
+// https://shopify.dev/donullcs/admin-api/rest/reference/orders/transaction?api[version]=2020-04
+interface Transaction {
+    amount: Decimal,
+    authorization: string,
+    created_at: string,
+    currency: string,
+    device_id: number,
+    error_code: string,
+    gateway: string,
+    id: number,
+    kind: string,
+    location_id: number,
+    message: string,
+    order_id: number,
+    payment_details: string,
+    parent_id: number,
+    processed_at: string,
+    receipt: any,
+    source_name: string,
+    status: string,
+    test: boolean,
+    user_id: number,
+    currency_exchange_adjustment: CurrencyExchangeAdjustment,
+};
+
+interface CurrencyExchangeAdjustment {
+    id: number,
+    adjustment: Decimal,
+    original_amount: Decimal,
+    final_amount: Decimal,
+    currency: string,
+};
+
+interface ShippingLine {
+    code: string,
+    price: Decimal,
+    price_set: PriceSet,
+    discounted_price: Decimal,
+    discounted_price_set: PriceSet,
+    source: string,
+    title: string,
+    tax_lines: TaxLine[],
+    carrier_identifier: string,
+    requested_fulfillment_service_id: string,
+};

--- a/dbcrossbarlib/src/drivers/mod.rs
+++ b/dbcrossbarlib/src/drivers/mod.rs
@@ -14,6 +14,7 @@ pub mod bigquery_schema;
 pub mod bigquery_shared;
 pub mod csv;
 pub mod dbcrossbar_schema;
+pub mod dbcrossbar_ts;
 pub mod gs;
 pub mod postgres;
 pub mod postgres_shared;
@@ -35,6 +36,7 @@ lazy_static! {
         driver::<bigquery_schema::BigQuerySchemaLocator>(),
         driver::<csv::CsvLocator>(),
         driver::<dbcrossbar_schema::DbcrossbarSchemaLocator>(),
+        driver::<dbcrossbar_ts::DbcrossbarTsLocator>(),
         driver::<gs::GsLocator>(),
         driver::<postgres::PostgresLocator>(),
         driver::<postgres_sql::PostgresSqlLocator>(),

--- a/dbcrossbarlib/src/lib.rs
+++ b/dbcrossbarlib/src/lib.rs
@@ -39,6 +39,7 @@ pub(crate) mod from_csv_cell;
 pub(crate) mod from_json_value;
 pub(crate) mod if_exists;
 pub(crate) mod locator;
+pub(crate) mod parse_error;
 pub(crate) mod path_or_stdio;
 pub mod rechunk;
 pub mod schema;

--- a/dbcrossbarlib/src/locator.rs
+++ b/dbcrossbarlib/src/locator.rs
@@ -197,6 +197,7 @@ fn locator_from_str_to_string_roundtrip() {
         "csv:file.csv",
         "csv:dir/",
         "dbcrossbar-schema:file.json",
+        "dbcrossbar-ts:file %231 20%25.ts#Type",
         "gs://example-bucket/tmp/",
         "postgres://localhost:5432/db#my_table",
         "postgres-sql:dir/my_table.sql",

--- a/dbcrossbarlib/src/parse_error.rs
+++ b/dbcrossbarlib/src/parse_error.rs
@@ -1,0 +1,118 @@
+//! A generic "parse error" with very fancy formatting.
+
+use codespan_reporting::{
+    diagnostic::{Diagnostic, Label},
+    files::SimpleFiles,
+    term,
+};
+use std::{error::Error as StdError, fmt, io::Cursor, ops::Range, sync::Arc};
+use termcolor::NoColor;
+
+/// An error occurred processing the schema.
+#[derive(Debug)]
+pub(crate) struct ParseError {
+    /// The name of the file in which the error occurred.
+    file_name: String,
+
+    /// Our input file. Yes, this is huge, so we store it behind a thread-safe
+    /// reference count using `Arc`.
+    file_string: Arc<String>,
+
+    /// The location of the error.
+    pub(crate) annotations: Vec<Annotation>,
+
+    /// The error message to display.
+    pub(crate) message: String,
+}
+
+impl ParseError {
+    /// Construct a parse error from an input file.
+    pub(crate) fn from_file_string(
+        file_name: String,
+        file_string: Arc<String>,
+        annotations: Vec<Annotation>,
+        message: String,
+    ) -> ParseError {
+        ParseError {
+            file_name,
+            file_string,
+            annotations,
+            message,
+        }
+    }
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Build a set of source files.
+        let mut files = SimpleFiles::new();
+        let file_id = files.add(&self.file_name, self.file_string.as_ref());
+
+        // Build our diagnostic.
+        let diagnostic = Diagnostic::error().with_message(&self.message).with_labels(
+            self.annotations
+                .iter()
+                .map(|a| match a.ty {
+                    AnnotationType::Primary => {
+                        Label::primary(file_id, &a.location).with_message(&a.message)
+                    }
+                    AnnotationType::Secondary => {
+                        Label::secondary(file_id, &a.location).with_message(&a.message)
+                    }
+                })
+                .collect(),
+        );
+
+        // Normally, we would write this directly to standard error with some
+        // pretty colors, but we can't do that inside `Display`, because we
+        // don't know if we're displaying to the terminal or not. So write
+        // everything to a local buffer.
+        let mut buf = Vec::with_capacity(1024);
+        let mut wtr = NoColor::new(Cursor::new(&mut buf));
+        let config = codespan_reporting::term::Config::default();
+        term::emit(&mut wtr, &config, &files, &diagnostic).map_err(|_| fmt::Error)?;
+        write!(f, "{}", String::from_utf8_lossy(&buf))
+    }
+}
+
+impl StdError for ParseError {}
+
+/// An annotation pointing at a particular part of our input.
+#[derive(Debug)]
+pub(crate) struct Annotation {
+    /// What type of annotation is this?
+    pub(crate) ty: AnnotationType,
+
+    /// What location are we annotating?
+    pub(crate) location: Location,
+
+    /// The message to display for this annotation.
+    pub(crate) message: String,
+}
+
+/// What type of annotation are we displaying?
+#[derive(Debug)]
+pub(crate) enum AnnotationType {
+    /// This the main source location associated with the error.
+    Primary,
+    /// This is a secondary source location associated with the error.
+    Secondary,
+}
+
+/// The location where an error occurred.
+#[derive(Debug)]
+pub(crate) enum Location {
+    /// This error occurred as a specific place in the source code.
+    Position(usize),
+    /// This error occurred at a span in the source code.
+    Range(Range<usize>),
+}
+
+impl<'a> From<&'a Location> for Range<usize> {
+    fn from(input: &'a Location) -> Self {
+        match input {
+            Location::Position(p) => *p..(*p + 1),
+            Location::Range(r) => r.to_owned(),
+        }
+    }
+}


### PR DESCRIPTION
We need some way to specify schemas containing complex, nested
structs. This will be particularly useful for BigQuery and for
importing structured JSON data.

You should now be able to write:

    dbcrossbar conv \
      'dbcrossbar-ts:schema.ts#Type' \
      dbcrossbar-schema:type.json

This is implemented using another `peg` parser, which parses
TypeScript using a Parser Expression Grammar (PEG). This is sort of
like a hierarchical regular expression with names rules.

We devote a substantial amount of effort to providing excellent error
messages that highlight errors directly in the TypeScript source.

We support basic types including `interface`, `type` (for aliases),
arrays, primitive types, and `field: ty | null` syntax. We require
semi-colons and commas everywhere they can go, though we may
eventually relax that.

---

**Review Note:** Be sure to expand `ast.ts`; it's where all the interesting bits are.