### PR TITLE
Improve decimal handling

### DIFF
--- a/dbcrossbar/fixtures/more_bq_types.csv
+++ b/dbcrossbar/fixtures/more_bq_types.csv
@@ -1,0 +1,2 @@
+numeric,numerics
+3.14,"[""3.14""]"

--- a/dbcrossbar/fixtures/more_bq_types.sql
+++ b/dbcrossbar/fixtures/more_bq_types.sql
@@ -1,0 +1,4 @@
+CREATE TABLE more_bq_types (
+    "numeric" numeric,
+    numerics numeric[]
+);

--- a/dbcrossbar/fixtures/shopify.ts
+++ b/dbcrossbar/fixtures/shopify.ts
@@ -1,10 +1,7 @@
 // This is a Shopify REST schema that we built by reading the docs.
 
 // A decimal value represented as a string for accuracy.
-type Decimal = string;
-
-// A type that we still need to look up.
-//type TODO = string;
+type decimal = string;
 
 // https://shopify.dev/docs/admin-api/rest/reference/orders/order?api[version]=2020-04
 interface Order {
@@ -57,14 +54,14 @@ interface Order {
     taxes_included: boolean | null,
     test: boolean | null,
     token: string | null,
-    total_discounts: Decimal | null,
+    total_discounts: decimal | null,
     total_discounts_set: PriceSet | null,
-    total_line_items_price: Decimal | null,
+    total_line_items_price: decimal | null,
     total_line_items_price_set: PriceSet | null,
     total_price_set: PriceSet | null,
-    total_tax: Decimal | null,
+    total_tax: decimal | null,
     total_tax_set: PriceSet | null,
-    total_tip_received: Decimal | null,
+    total_tip_received: decimal | null,
     total_weight: number | null,
     updated_at: string | null,
     user_id: number | null,
@@ -122,7 +119,7 @@ interface Customer {
     tags: string | null,
     tax_exempt: boolean | null,
     tax_exemptions: string[] | null,
-    total_spent: Decimal | null,
+    total_spent: decimal | null,
     updated_at: string | null,
     verified_email: boolean | null,
 }
@@ -130,7 +127,7 @@ interface Customer {
 interface DiscountApplication {
     type: string | null,
     description: string | null,
-    value: Decimal | null,
+    value: decimal | null,
     value_type: string | null,
     allocation_method: string | null,
     target_selection: string | null,
@@ -139,7 +136,7 @@ interface DiscountApplication {
 
 interface DiscountCode {
     code: string | null,
-    amount: Decimal | null,
+    amount: decimal | null,
     type: string | null,
 }
 
@@ -169,7 +166,7 @@ interface LineItem {
     fulfillment_status: string | null,
     grams: number | null,
     id: number,
-    price: Decimal | null,
+    price: decimal | null,
     product_id: number | null,
     quantity: number | null,
     requires_shipping: boolean | null,
@@ -184,7 +181,7 @@ interface LineItem {
     properties: Property[] | null,
     taxable: boolean | null,
     tax_lines: TaxLine[] | null,
-    total_discount: Decimal | null,
+    total_discount: decimal | null,
     total_discount_set: PriceSet | null,
     discount_allocations: DiscountAllocation[] | null,
     duties: Duty[] | null,
@@ -203,7 +200,7 @@ interface PriceSet {
 }
 
 interface Money {
-    amount: Decimal | null,
+    amount: decimal | null,
     currency_code: string | null,
 }
 
@@ -220,7 +217,7 @@ interface TaxLine {
 }
 
 interface DiscountAllocation {
-    amount: Decimal | null,
+    amount: decimal | null,
     discount_application_index: number | null,
     amount_set: PriceSet | null,
 }
@@ -261,8 +258,8 @@ interface OrderAdjustment {
     id: number,
     order_id: number,
     refund_id: number | null,
-    amount: Decimal | null,
-    tax_amount: Decimal | null,
+    amount: decimal | null,
+    tax_amount: decimal | null,
     kind: string | null,
     reason: string | null,
     amount_set: PriceSet | null,
@@ -284,7 +281,7 @@ interface RefundLineItem {
 
 // https://shopify.dev/donullcs/admin-api/rest/reference/orders/transaction?api[version]=2020-04
 interface Transaction {
-    amount: Decimal | null,
+    amount: decimal | null,
     authorization: string | null,
     created_at: string | null,
     currency: string | null,
@@ -309,17 +306,17 @@ interface Transaction {
 
 interface CurrencyExchangeAdjustment {
     id: number,
-    adjustment: Decimal | null,
-    original_amount: Decimal | null,
-    final_amount: Decimal | null,
+    adjustment: decimal | null,
+    original_amount: decimal | null,
+    final_amount: decimal | null,
     currency: string | null,
 }
 
 interface ShippingLine {
     code: string | null,
-    price: Decimal | null,
+    price: decimal | null,
     price_set: PriceSet | null,
-    discounted_price: Decimal | null,
+    discounted_price: decimal | null,
     discounted_price_set: PriceSet | null,
     source: string | null,
     title: string | null,

--- a/dbcrossbar/fixtures/structs/struct-data-type-after-bq.json
+++ b/dbcrossbar/fixtures/structs/struct-data-type-after-bq.json
@@ -25,6 +25,11 @@
             }
         },
         {
+            "name": "decimal",
+            "is_nullable": true,
+            "data_type": "decimal"
+        },
+        {
             "name": "float32",
             "is_nullable": true,
             "data_type": "float64"

--- a/dbcrossbar/fixtures/structs/struct-data-type.json
+++ b/dbcrossbar/fixtures/structs/struct-data-type.json
@@ -25,6 +25,11 @@
             }
         },
         {
+            "name": "decimal",
+            "is_nullable": true,
+            "data_type": "decimal"
+        },
+        {
             "name": "float32",
             "is_nullable": true,
             "data_type": "float32"

--- a/dbcrossbar/fixtures/structs/struct.json
+++ b/dbcrossbar/fixtures/structs/struct.json
@@ -7,6 +7,7 @@
     "date_array": [
         "1969-07-20"
     ],
+    "decimal": "3.14",
     "float32": 0,
     "float64": 0,
     "geojson_3857": {

--- a/dbcrossbar/tests/cli/cp/bigquery.rs
+++ b/dbcrossbar/tests/cli/cp/bigquery.rs
@@ -105,6 +105,50 @@ fn cp_csv_to_bigquery_to_csv() {
 
 #[test]
 #[ignore]
+fn cp_more_bigquery_types() {
+    let _ = env_logger::try_init();
+    let testdir = TestDir::new("dbcrossbar", "cp_more_bigquery_types");
+    let src = testdir.src_path("fixtures/more_bq_types.csv");
+    let schema = testdir.src_path("fixtures/more_bq_types.sql");
+    let bq_temp_ds = bq_temp_dataset();
+    let gs_temp_dir = gs_test_dir_url("cp_more_bigquery_types");
+    let bq_table = bq_test_table("cp_more_bigquery_types");
+
+    // CSV to BigQuery.
+    testdir
+        .cmd()
+        .args(&[
+            "cp",
+            "--if-exists=overwrite",
+            &format!("--temporary={}", gs_temp_dir),
+            &format!("--temporary={}", bq_temp_ds),
+            &format!("--schema=postgres-sql:{}", schema.display()),
+            &format!("csv:{}", src.display()),
+            &bq_table,
+        ])
+        .tee_output()
+        .expect_success();
+
+    // BigQuery to CSV.
+    testdir
+        .cmd()
+        .args(&[
+            "cp",
+            "--if-exists=overwrite",
+            &format!("--temporary={}", gs_temp_dir),
+            &format!("--temporary={}", bq_temp_ds),
+            &bq_table,
+            "csv:out.csv",
+        ])
+        .tee_output()
+        .expect_success();
+
+    let expected = fs::read_to_string(&src).unwrap();
+    testdir.expect_file_contents("out.csv", &expected);
+}
+
+#[test]
+#[ignore]
 fn bigquery_record_columns() {
     let testdir = TestDir::new("dbcrossbar", "bigquery_record_columns");
     let bq_temp_ds = bq_temp_dataset();

--- a/dbcrossbarlib/src/drivers/bigquery_shared/import_udf.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/import_udf.rs
@@ -79,6 +79,7 @@ fn write_non_array_transform_expr(
         BqNonArrayDataType::Bool
         | BqNonArrayDataType::Float64
         | BqNonArrayDataType::Int64
+        | BqNonArrayDataType::Numeric
         | BqNonArrayDataType::String => {
             write!(f, "{}", input_expr)?;
         }
@@ -145,7 +146,6 @@ fn write_non_array_transform_expr(
         BqNonArrayDataType::Datetime
         | BqNonArrayDataType::Bytes
         | BqNonArrayDataType::Geography
-        | BqNonArrayDataType::Numeric
         | BqNonArrayDataType::Time => {
             return Err(format_err!(
                 "cannot import nested values of type {} into BigQuery yet",


### PR DESCRIPTION
We make sure that exact decimal numbers work with BigQuery and with
`dbcrossbar-ts`. The latter is a little magic.