### PR TITLE
bigquery: Optionally specifiy job labels (fixes #123)

### DIFF
--- a/dbcrossbar/tests/cli/cp/bigquery.rs
+++ b/dbcrossbar/tests/cli/cp/bigquery.rs
@@ -82,6 +82,7 @@ fn cp_csv_to_bigquery_to_csv() {
             &format!("--temporary={}", gs_temp_dir),
             &format!("--temporary={}", bq_temp_ds),
             &format!("--schema=postgres-sql:{}", schema.display()),
+            "--to-arg=job_labels[dbcrossbar_test]=true",
             &format!("csv:{}", src.display()),
             &bq_table,
         ])
@@ -96,6 +97,7 @@ fn cp_csv_to_bigquery_to_csv() {
             "--if-exists=overwrite",
             &format!("--temporary={}", gs_temp_dir),
             &format!("--temporary={}", bq_temp_ds),
+            "--from-arg=job_labels[dbcrossbar_test]=true",
             &bq_table,
             "csv:out/",
         ])

--- a/dbcrossbarlib/src/clouds/gcloud/bigquery/extract.rs
+++ b/dbcrossbarlib/src/clouds/gcloud/bigquery/extract.rs
@@ -2,7 +2,7 @@
 
 use super::{
     super::Client,
-    jobs::{run_job, Job, JobConfigurationExtract, TableReference},
+    jobs::{run_job, Job, JobConfigurationExtract, Labels, TableReference},
 };
 
 use crate::common::*;
@@ -13,6 +13,7 @@ pub(crate) async fn extract(
     ctx: &Context,
     source_table: &TableName,
     dest_gs_url: &Url,
+    labels: &Labels,
 ) -> Result<()> {
     trace!(ctx.log(), "extract {} into {}", source_table, dest_gs_url);
 
@@ -28,7 +29,7 @@ pub(crate) async fn extract(
         ctx,
         &client,
         source_table.project(),
-        Job::new_extract(config),
+        Job::new_extract(config, labels.to_owned()),
     )
     .await?;
     Ok(())

--- a/dbcrossbarlib/src/clouds/gcloud/bigquery/load.rs
+++ b/dbcrossbarlib/src/clouds/gcloud/bigquery/load.rs
@@ -3,7 +3,7 @@
 use super::{
     super::Client,
     jobs::{
-        run_job, CreateDisposition, Job, JobConfigurationLoad, TableReference,
+        run_job, CreateDisposition, Job, JobConfigurationLoad, Labels, TableReference,
         WriteDisposition,
     },
     TableSchema,
@@ -18,6 +18,7 @@ pub(crate) async fn load(
     gs_url: &Url,
     dest_table: &BqTable,
     if_exists: &IfExists,
+    labels: &Labels,
 ) -> Result<()> {
     trace!(ctx.log(), "loading {} into {}", gs_url, dest_table.name);
 
@@ -40,7 +41,7 @@ pub(crate) async fn load(
         ctx,
         &client,
         dest_table.name.project(),
-        Job::new_load(config),
+        Job::new_load(config, labels.to_owned()),
     )
     .await?;
     Ok(())

--- a/dbcrossbarlib/src/clouds/gcloud/bigquery/mod.rs
+++ b/dbcrossbarlib/src/clouds/gcloud/bigquery/mod.rs
@@ -13,6 +13,7 @@ mod queries;
 mod schema;
 
 pub(crate) use extract::*;
+pub(crate) use jobs::Labels;
 pub(crate) use load::*;
 pub(crate) use queries::*;
 pub(crate) use schema::*;
@@ -55,9 +56,13 @@ pub(crate) struct TableSchema {
 }
 
 /// Drop a table from BigQuery.
-pub(crate) async fn drop_table(ctx: &Context, table_name: &TableName) -> Result<()> {
+pub(crate) async fn drop_table(
+    ctx: &Context,
+    table_name: &TableName,
+    labels: &Labels,
+) -> Result<()> {
     // Delete temp table.
     debug!(ctx.log(), "deleting table: {}", table_name);
     let sql = format!("DROP TABLE {};\n", table_name.dotted_and_quoted());
-    execute_sql(ctx, table_name.project(), &sql).await
+    execute_sql(ctx, table_name.project(), &sql, labels).await
 }

--- a/dbcrossbarlib/src/driver_args.rs
+++ b/dbcrossbarlib/src/driver_args.rs
@@ -1,33 +1,29 @@
 use serde::de::DeserializeOwned;
-use serde_json::{map::Entry, Map, Value};
-use std::iter::FromIterator;
+use serde_json::{Map, Value};
+use std::{ops::Range, str::FromStr, sync::Arc};
 
 use crate::common::*;
+use crate::parse_error::{Annotation, FileInfo, ParseError};
 
 /// Driver-specific arguments.
 #[derive(Clone, Debug, Default)]
 pub struct DriverArguments {
-    /// A list of key-value pairs, in order.
-    args: Vec<(String, String)>,
+    /// A list of arguments pairs, in order.
+    args: Vec<Arg>,
 }
 
 impl DriverArguments {
     /// Parse a list of command-line arguments of the form `key=value` into a
     /// `DriverArgs` structure.
-    pub fn from_cli_args(args: &[String]) -> Result<Self> {
+    pub fn from_cli_args<I>(args: I) -> Result<Self>
+    where
+        I: IntoIterator,
+        I::Item: AsRef<str>,
+    {
         let args = args
-            .iter()
-            .map(|arg| -> Result<(String, String)> {
-                let split = arg.splitn(2, '=').collect::<Vec<_>>();
-                if split.len() != 2 {
-                    return Err(format_err!(
-                        "cannot parse driver argument: {:?}",
-                        arg
-                    ));
-                }
-                Ok((split[0].to_owned(), split[1].to_owned()))
-            })
-            .collect::<Result<Vec<_>>>()?;
+            .into_iter()
+            .map(|s| Arg::from_str(s.as_ref()))
+            .collect::<Result<Vec<_>, _>>()?;
         Ok(Self { args })
     }
 
@@ -36,63 +32,19 @@ impl DriverArguments {
         self.args.is_empty()
     }
 
-    /// Return an iterator over the key-value pairs of this `DriverArgs`.
-    pub(crate) fn iter(&self) -> impl Iterator<Item = (&str, &str)> {
-        self.args.iter().map(|(k, v)| (&k[..], &v[..]))
-    }
-
     /// Convert these arguments to a JSON object. We treat keys of the form
     /// "parent.nested" as `{ "parent": { "nested": ... } }`.
     fn to_json(&self) -> Result<Value> {
-        let mut map = Map::new();
-        for (k, v) in &self.args {
-            let path = k.split('.').collect::<Vec<_>>();
-            let mut m = &mut map;
-            for &ancestor in &path[..path.len() - 1] {
-                m = match m.entry(ancestor) {
-                    Entry::Vacant(vacant) => vacant
-                        .insert(Value::Object(Map::new()))
-                        .as_object_mut()
-                        .expect("inserted Value::Object but didn't get it back"),
-                    Entry::Occupied(occupied) => match occupied.into_mut() {
-                        Value::Object(new_m) => new_m,
-                        value => {
-                            return Err(format_err!(
-                                "argument {:?} conflicts with existing {:?} value {}",
-                                k,
-                                ancestor,
-                                value,
-                            ));
-                        }
-                    },
-                };
-            }
-            let mut last_segment = path[path.len() - 1];
-            if last_segment.ends_with("[]") {
-                last_segment = &last_segment[..last_segment.len() - 2];
-                let arr = match m.entry(last_segment) {
-                    Entry::Vacant(vacant) => vacant
-                        .insert(Value::Array(vec![]))
-                        .as_array_mut()
-                        .expect("inserted Value::Array but didn't get it back"),
-                    Entry::Occupied(occupied) => match occupied.into_mut() {
-                        Value::Array(arr) => arr,
-                        value => {
-                            return Err(format_err!(
-                                "argument {:?} conflicts with existing {:?} value {}",
-                                k,
-                                last_segment,
-                                value,
-                            ));
-                        }
-                    },
-                };
-                arr.push(Value::String(v.to_owned()));
-            } else {
-                m.insert(last_segment.to_owned(), Value::String(v.to_owned()));
-            }
+        let mut json = Value::Object(Map::new());
+        for arg in &self.args {
+            insert_into_json(
+                &mut json,
+                &arg.file_info,
+                &arg.name.0,
+                arg.value.to_owned(),
+            )?;
         }
-        Ok(Value::Object(map))
+        Ok(json)
     }
 
     /// Deserialize our driver arguments into a struct of type `T` using
@@ -105,38 +57,176 @@ impl DriverArguments {
 #[test]
 fn to_json_handles_nested_keys() {
     use serde_json::json;
-    let raw_args = &[("a", "b"), ("c.d", "x"), ("c.e[]", "y"), ("c.e[]", "z")];
-    let args = DriverArguments::from_iter(raw_args.iter().cloned());
+    let raw_args = &["a=b", "c.d=x", "c.e[]=y", "c[e][]=z"];
+    let args = DriverArguments::from_cli_args(raw_args).unwrap();
     assert_eq!(
         args.to_json().unwrap(),
         json!({"a": "b", "c": { "d": "x", "e": ["y", "z"] } }),
     );
-
-    let raw_conflicting_args = &[("a", "x"), ("a.b", "y")];
-    let conflicting_args =
-        DriverArguments::from_iter(raw_conflicting_args.iter().cloned());
-    assert!(conflicting_args.to_json().is_err());
-
-    let raw_conflicting_args_2 = &[("a", "x"), ("a[]", "y")];
-    let conflicting_args_2 =
-        DriverArguments::from_iter(raw_conflicting_args_2.iter().cloned());
-    assert!(conflicting_args_2.to_json().is_err());
 }
 
-impl<K, V> FromIterator<(K, V)> for DriverArguments
-where
-    K: Into<String>,
-    V: Into<String>,
-{
-    /// Construct a `DriverArgs` from key/value pairs.
-    fn from_iter<T>(iter: T) -> Self
-    where
-        T: IntoIterator<Item = (K, V)>,
-    {
-        let args = iter
-            .into_iter()
-            .map(|(k, v)| (k.into(), v.into()))
-            .collect();
-        Self { args }
+#[test]
+fn to_json_detects_conflicts() {
+    let conflicts = &[&["a=x", "a=y"], &["a=x", "a.b=y"], &["a=x", "a[]=y"]];
+    for &conflict in conflicts {
+        let conflicting_args = DriverArguments::from_cli_args(conflict).unwrap();
+        assert!(conflicting_args.to_json().is_err());
+    }
+}
+
+/// The name of a driver argument.
+#[derive(Clone, Debug)]
+pub(self) struct Arg {
+    file_info: Arc<FileInfo>,
+    name: ArgName,
+    value: Value,
+}
+
+impl FromStr for Arg {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let name = "driver argument";
+        let file_info = Arc::new(FileInfo::new(name.to_owned(), s.to_owned()));
+        grammar::arg(s, &file_info).map_err(|err| {
+            ParseError::new(
+                file_info.clone(),
+                vec![Annotation::primary(
+                    err.location.offset,
+                    format!("expected {}", err.expected),
+                )],
+                format!("error parsing {}", file_info.name),
+            )
+        })
+    }
+}
+
+/// An `ArgName` must start with a `Component::Member`, followed any number of
+/// non-`Component::FinalArray` value, and finish with a optional
+/// `Component::FinalArray`. These rules are enforced by the parser's grammar.
+#[derive(Clone, Debug)]
+pub(self) struct ArgName(Vec<Component>);
+
+/// A component of the name of a driver argument.
+#[derive(Clone, Debug)]
+pub(self) enum Component {
+    /// A ".name" or `[name]` expression.
+    Member(Range<usize>, String),
+    /// A "[]" expression, which can only appear at the end.
+    FinalArray(Range<usize>),
+}
+
+peg::parser! {
+    /// A grammar for parsing driver argument names and values.
+    grammar grammar() for str {
+        /// A driver argument.
+        pub(super) rule arg(file_info: &Arc<FileInfo>) -> Arg
+            = name:arg_name() "=" value:value() { Arg { file_info: file_info.to_owned(), name, value }}
+
+        /// A driver argument name.
+        rule arg_name() -> ArgName
+            = initial:initial() rest:(component()*) final_array:final_array() {
+                let mut path = Vec::with_capacity(2 + rest.len());
+                path.push(initial);
+                path.extend(rest);
+                if let Some(final_array) = final_array {
+                    path.push(final_array);
+                }
+                ArgName(path)
+            }
+
+        /// The first component of a driver argument.
+        rule initial() -> Component
+            = s:position!() id:id() e:position!() { Component::Member(s..e, id) }
+
+        /// A single component in the name of a driver argument.
+        rule component() -> Component
+            = s:position!() "." id:id() e:position!() { Component::Member(s..e, id) }
+            / s:position!() "[" id:id() "]" e:position!() { Component::Member(s..e, id) }
+
+        /// An optional final `[]` component.
+        rule final_array() -> Option<Component>
+           = s:position!() "[]" e:position!() { Some(Component::FinalArray(s..e)) }
+           / { None }
+
+        /// An identifier.
+        rule id() -> String
+            = quiet! {
+                id:$(
+                    ['A'..='Z' | 'a'..='z' | '_']
+                    ['A'..='Z' | 'a'..='z' | '_' | '0'..='9']*
+                )
+                { id.to_owned() }
+            }
+            / expected!("identifier")
+
+        rule value() -> Value
+            = s:$([_]*) { Value::String(s.to_owned()) }
+    }
+}
+
+/// Insert `value` into `json` at `path`.
+///
+/// `path` must never be empty. If `json` is `Value::Null`, it will be replaced
+/// with either a JSON object or a JSON array, depending on the type of the next
+/// component in `path`.
+fn insert_into_json(
+    json: &mut Value,
+    file_info: &Arc<FileInfo>,
+    path: &[Component],
+    value: Value,
+) -> Result<(), ParseError> {
+    // We should never be called with an empty path.
+    assert!(!path.is_empty());
+
+    // Helper function that builds a useful error.
+    let conflict_err =
+        |pos: &Range<usize>, message: &'static str, existing: &Value| {
+            let existing = serde_json::to_string(existing).unwrap();
+            ParseError::new(
+                file_info.to_owned(),
+                vec![Annotation::primary(pos.to_owned(), "conflict here")],
+                format!("{}, but earlier arguments specified {}", message, existing),
+            )
+        };
+
+    // Create a location where our next value will be stored, and temporarily
+    // fill it with `Value::None`.
+    let (pos, place) = match &path[0] {
+        Component::Member(pos, key) => {
+            if let Value::Null = json {
+                *json = Value::Object(Map::new());
+            }
+            if let Value::Object(obj) = json {
+                Ok((pos, obj.entry(key).or_insert(Value::Null)))
+            } else {
+                Err(conflict_err(pos, "tried to insert into a hash", json))
+            }
+        }
+        Component::FinalArray(pos) => {
+            if let Value::Null = json {
+                *json = Value::Array(vec![]);
+            }
+            if let Value::Array(arr) = json {
+                arr.push(Value::Null);
+                Ok((pos, arr.last_mut().expect("array should have item")))
+            } else {
+                Err(conflict_err(pos, "tried to append to an array", json))
+            }
+        }
+    }?;
+
+    // Decide what to store in `place`.
+    if path.len() == 1 {
+        // This is our last path component, so store our value.
+        if let Value::Null = place {
+            *place = value;
+            Ok(())
+        } else {
+            Err(conflict_err(pos, "tried to set a value", json))
+        }
+    } else {
+        // We have more path components, so recurse.
+        insert_into_json(place, file_info, &path[1..], value)
     }
 }

--- a/dbcrossbarlib/src/drivers/bigquery/mod.rs
+++ b/dbcrossbarlib/src/drivers/bigquery/mod.rs
@@ -130,8 +130,9 @@ impl LocatorStatic for BigQueryLocator {
                 | LocatorFeatures::WriteLocalData
                 | LocatorFeatures::Count,
             write_schema_if_exists: EnumSet::empty(),
-            source_args: SourceArgumentsFeatures::WhereClause.into(),
-            dest_args: EnumSet::empty(),
+            source_args: SourceArgumentsFeatures::DriverArgs
+                | SourceArgumentsFeatures::WhereClause,
+            dest_args: DestinationArgumentsFeatures::DriverArgs.into(),
             dest_if_exists: IfExistsFeatures::Error
                 | IfExistsFeatures::Overwrite
                 | IfExistsFeatures::Append

--- a/dbcrossbarlib/src/drivers/bigquery_shared/driver_args.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/driver_args.rs
@@ -1,0 +1,14 @@
+//! Arguments which can be passed to various Google Cloud drivers.
+
+use serde::Deserialize;
+
+use crate::clouds::gcloud::bigquery::Labels;
+
+/// Parse version of `--to-arg` and `--from-arg` labels.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct GCloudDriverArguments {
+    /// Billing labels to apply to objects and jobs.
+    #[serde(default)]
+    pub(crate) job_labels: Labels,
+}

--- a/dbcrossbarlib/src/drivers/bigquery_shared/mod.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/mod.rs
@@ -13,6 +13,7 @@
 mod column;
 mod column_name;
 mod data_type;
+mod driver_args;
 mod export_udf;
 mod import_udf;
 mod indent_level;
@@ -22,5 +23,6 @@ mod table_name;
 pub(crate) use self::column::*;
 pub(crate) use self::column_name::*;
 pub(crate) use self::data_type::*;
+pub(crate) use self::driver_args::*;
 pub(crate) use self::table::*;
 pub(crate) use self::table_name::*;

--- a/dbcrossbarlib/src/drivers/redshift/mod.rs
+++ b/dbcrossbarlib/src/drivers/redshift/mod.rs
@@ -3,6 +3,7 @@
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::{
+    collections::HashMap,
     fmt,
     str::{self, FromStr},
 };
@@ -146,10 +147,11 @@ impl LocatorStatic for RedshiftLocator {
 /// Given a `DriverArgs` structure, convert it into Redshift credentials SQL.
 pub(crate) fn credentials_sql(args: &DriverArguments) -> Result<String> {
     let mut out = vec![];
-    for (k, v) in args.iter() {
+    let map = args.deserialize::<HashMap<String, String>>()?;
+    for (k, v) in &map {
         lazy_static! {
             static ref KEY_RE: Regex =
-                Regex::new("^[-_A-Za-z0-9]+$").expect("invalid regex in source code");
+                Regex::new("^[_A-Za-z0-9]+$").expect("invalid regex in source code");
         }
         if !KEY_RE.is_match(k) {
             return Err(format_err!("cannot pass {:?} as Redshift credential", k));

--- a/guide/src/bigquery.md
+++ b/guide/src/bigquery.md
@@ -19,6 +19,11 @@ The following command-line options will usually need to be specified for both so
 - `--temporary=gs://$GS_TEMP_BUCKET`: A Google Cloud Storage bucket to use for staging data in both directions.
 - `--temporary=bigquery:$GCLOUD_PROJECT:temp_dataset`
 
+You can also specify Google Cloud resource labels to apply to all BigQuery jobs. Labels are often used to track query costs.
+
+- `--from-arg=job_labels[department]=marketing`
+- `--to-arg=job_labels[project]=project1`
+
 ## Supported features
 
 ```txt


### PR DESCRIPTION
Google Cloud allows specifying optional labels on many kinds of resources, in order to help keep track of costs. This implements basic labels for BigQuery jobs, but nothing else. Please see the individual commit messages for details, and see the change to `bigquery.md` for documentation about how to specify labels.

This implements a stable API that we can live with, so we don't need to hide it behind `--enable-unstable`.

### Previous Discussion questions (obsolete)

- We can, in theory, apply labels to all of the following. Which do we need urgently?
  - **Done:** BigQuery jobs, including import, export and query. This may also apply to tables created automatically as part of a job; I need to look into that.
  - **TODO:** BigQuery tables. But we need to be careful here, because just because a table was _created_ by a specific dbcrossbar caller, that doesn't mean we want to bill that table to the original caller forever. Also we might need to pre-create more tables and rely less on jobs that create their own destination tables implicitly.
  - **???:** Google Cloud Storage buckets. Probably not individual objects in buckets, but I could check.
- We may want to distinguish labels on the jobs we run to create a table from labels on the resulting table.
- Do we want to automatically label things with a `dbcrossbar_vers:$VERSION` tag?
- Do we want to automatically label things where the user _didn't_ specify a label, using, for example, something like `dbcrossbar:unlabeled`?