### PR TITLE
gs: Verify generations & CRC32C checksums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,6 +297,11 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "crc32c"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "crossbeam"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,6 +479,7 @@ dependencies = [
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "codespan-reporting 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "common_failures 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc32c 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2572,6 +2578,7 @@ dependencies = [
 "checksum constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 "checksum core-foundation 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
 "checksum core-foundation-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
+"checksum crc32c 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "77ba37ef26c12988c1cee882d522d65e1d5d2ad8c3864665b88ee92767ed84c5"
 "checksum crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
 "checksum crossbeam-channel 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061"
 "checksum crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"

--- a/dbcrossbarlib/Cargo.toml
+++ b/dbcrossbarlib/Cargo.toml
@@ -29,6 +29,7 @@ cast = "0.2.3"
 chrono = "0.4.6"
 codespan-reporting = "0.9.3"
 common_failures = "0.1.1"
+crc32c = "0.4.0"
 csv = "1.0.5"
 diesel = { version = "1.3.3", features = ["postgres"] }
 dirs = "2.0.2"

--- a/dbcrossbarlib/src/clouds/gcloud/bigquery/jobs.rs
+++ b/dbcrossbarlib/src/clouds/gcloud/bigquery/jobs.rs
@@ -311,7 +311,9 @@ pub(crate) async fn run_job(
         "https://bigquery.googleapis.com/bigquery/v2/projects/{}/jobs",
         project_id,
     );
-    job = client.post::<Job, _, _>(ctx, &insert_url, job).await?;
+    job = client
+        .post::<Job, _, _, _>(ctx, &insert_url, NoQuery, job)
+        .await?;
 
     // Get the URL for polling the job.
     let job_url = job.url()?;

--- a/dbcrossbarlib/src/clouds/gcloud/client.rs
+++ b/dbcrossbarlib/src/clouds/gcloud/client.rs
@@ -35,20 +35,6 @@ pub(crate) enum Alt {
     Proto,
 }
 
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct AltQuery {
-    /// What format should we return?
-    pub(crate) alt: Alt,
-}
-
-impl AltQuery {
-    /// Create an `alt=media` query.
-    pub(crate) fn media() -> AltQuery {
-        AltQuery { alt: Alt::Media }
-    }
-}
-
 /// A Google Cloud REST client using OAuth2.
 pub(crate) struct Client {
     /// An authenticator that provides OAuth2 tokens.
@@ -130,18 +116,20 @@ impl Client {
     }
 
     /// Make an HTTP POST request with the specified URL and body.
-    pub(crate) async fn post<Output, U, Body>(
+    pub(crate) async fn post<Output, U, Query, Body>(
         &self,
         ctx: &Context,
         url: U,
+        query: Query,
         body: Body,
     ) -> Result<Output>
     where
         Output: fmt::Debug + DeserializeOwned,
         U: IntoUrl,
+        Query: fmt::Debug + Serialize,
         Body: fmt::Debug + Serialize,
     {
-        let url = url.into_url()?;
+        let url = build_url(url, query)?;
         trace!(ctx.log(), "POST {} {:?}", url, body);
         trace!(ctx.log(), "serialied {}", serde_json::to_string(&body)?);
         let token = self.token().await?;

--- a/dbcrossbarlib/src/clouds/gcloud/crc32c_stream.rs
+++ b/dbcrossbarlib/src/clouds/gcloud/crc32c_stream.rs
@@ -1,0 +1,157 @@
+//! Streams which keep a running CRC32 digest of the data that passes through them.
+
+use crc32c::crc32c_append;
+use futures::TryStream;
+use std::{pin::Pin, task::Poll};
+use tokio::sync::oneshot;
+
+use crate::common::*;
+
+/// A GCloud-compatible CRC32C hasher.
+///
+/// This uses the popular Rust `Hasher` API to wrap a lower-level library.
+#[derive(Clone, Debug)]
+pub(crate) struct Hasher {
+    state: u32,
+}
+
+impl Hasher {
+    /// Create a new `Hasher` with the default state.
+    fn new() -> Self {
+        Self { state: 0 }
+    }
+
+    /// Update the hasher with new data.
+    fn update(&mut self, data: &[u8]) {
+        self.state = crc32c_append(self.state, data);
+    }
+
+    /// Finish hashing and return our underlying value.
+    ///
+    /// This consumes `self` because that's how some other Rust `Hasher` types
+    /// work.
+    pub(crate) fn finish(self) -> u32 {
+        self.state
+    }
+
+    /// Finish hashing and return our underlying value as a big-endian Base64
+    /// string.
+    pub(crate) fn finish_encoded(self) -> String {
+        let bytes = self.finish().to_be_bytes();
+        base64::encode(&bytes)
+    }
+}
+
+#[test]
+fn crc32c_matches_gcloud() {
+    // Check that `data` hashes to `expected`.
+    let check = |data: &[u8], expected: u32| {
+        let mut hasher = Hasher::new();
+        hasher.update(data);
+        assert_eq!(hasher.finish(), expected);
+    };
+
+    // These test cases are from https://tools.ietf.org/html/rfc3720#page-217
+    // and https://github.com/google/crc32c/blob/master/src/crc32c_unittest.cc
+    check(&[0u8; 32], 0x8a91_36aa);
+    check(&[0xff; 32], 0x62a8_ab43);
+    let mut buf = [0u8; 32];
+    for i in 0u8..=31 {
+        buf[usize::from(i)] = i;
+    }
+    check(&buf, 0x46dd_794e);
+    for i in 0u8..=31 {
+        buf[usize::from(i)] = 31 - i;
+    }
+    check(&buf, 0x113f_db5c);
+}
+
+/// Wrap the stream `S`, and keep a running CRC32 hash of the data we see on the
+/// stream. When the stream is finished, send the hash to a listener.
+pub(crate) struct Crc32cStream<S>
+where
+    // We require `Unpin` here, because it allows us to access `self.inner`
+    // without using `unsafe`, which we avoid in `dbcrossbar`. Happily,
+    // `BoxStream` implements `Unpin`, so this restriction isn't overly
+    // limiting.
+    S: TryStream<Error = Error> + Send + Unpin + 'static,
+    S::Ok: AsRef<[u8]>,
+{
+    /// The wrapped stream.
+    inner: S,
+
+    /// A CRC32 hasher.
+    hasher: Hasher,
+
+    /// A sender which will receive `hasher` when the stream has finished.
+    sender: Option<oneshot::Sender<Hasher>>,
+}
+
+impl<S> Crc32cStream<S>
+where
+    S: TryStream<Error = Error> + Send + Unpin + 'static,
+    S::Ok: AsRef<[u8]>,
+{
+    /// Create a new `Crc32Stream` wrapping `inner`.
+    pub(crate) fn new(inner: S) -> (Self, oneshot::Receiver<Hasher>) {
+        let hasher = Hasher::new();
+        let (sender, receiver) = oneshot::channel();
+        (
+            Self {
+                inner,
+                hasher,
+                sender: Some(sender),
+            },
+            receiver,
+        )
+    }
+}
+
+impl<S, D> Stream for Crc32cStream<S>
+where
+    // We need a slightly more complicated version of these bounds here.
+    S: TryStream<Ok = D, Error = Error, Item = Result<D, Error>>
+        + Send
+        + Unpin
+        + 'static,
+    D: AsRef<[u8]>,
+{
+    type Item = Result<S::Ok, S::Error>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        let result = <S as Stream>::poll_next(Pin::new(&mut self.inner), cx);
+        match result {
+            // We've received data.
+            Poll::Ready(Some(Ok(data))) => {
+                self.hasher.update(data.as_ref());
+                Poll::Ready(Some(Ok(data)))
+            }
+
+            // We've reached the end of the stream.
+            Poll::Ready(None) => {
+                // Send our hash. We can do this in a `poll_*` method because
+                // `oneshot::Sender::send` is synchronous, and we don't have to
+                // wait for it.
+                if let Some(sender) = self.sender.take() {
+                    if sender.send(self.hasher.clone()).is_ok() {
+                        Poll::Ready(None)
+                    } else {
+                        Poll::Ready(Some(Err(format_err!(
+                            "broken pipe forwarding checksum from Crc32Stream",
+                        ))))
+                    }
+                } else {
+                    Poll::Ready(Some(Err(format_err!(
+                        "Crc32Stream tried to end twice",
+                    ))))
+                }
+            }
+
+            // Something else has happened.
+            other => other,
+        }
+    }
+}

--- a/dbcrossbarlib/src/clouds/gcloud/mod.rs
+++ b/dbcrossbarlib/src/clouds/gcloud/mod.rs
@@ -3,6 +3,7 @@
 pub(crate) mod auth;
 pub(crate) mod bigquery;
 mod client;
+pub(crate) mod crc32c_stream;
 pub(crate) mod storage;
 
 pub(crate) use client::*;

--- a/dbcrossbarlib/src/clouds/gcloud/storage/upload_file.rs
+++ b/dbcrossbarlib/src/clouds/gcloud/storage/upload_file.rs
@@ -3,8 +3,8 @@
 use serde::Serialize;
 
 use super::{
-    super::{percent_encode, Client},
-    parse_gs_url,
+    super::{crc32c_stream::Crc32cStream, percent_encode, Client, NoQuery},
+    parse_gs_url, StorageObject,
 };
 use crate::common::*;
 use crate::tokio_glue::idiomatic_bytes_stream;
@@ -15,6 +15,10 @@ use crate::tokio_glue::idiomatic_bytes_stream;
 struct UploadQuery {
     /// The type of the upload we're performing.
     upload_type: &'static str,
+
+    /// Only accept the upload if the existing object has the specified
+    /// generation number. Use 0 to specify a non-existant object.
+    if_generation_match: i64,
 
     /// The name of the object we're creating.
     name: String,
@@ -29,20 +33,52 @@ pub(crate) async fn upload_file<'a>(
     ctx: &'a Context,
     data: BoxStream<BytesMut>,
     file_url: &'a Url,
-) -> Result<()> {
+) -> Result<StorageObject> {
     debug!(ctx.log(), "streaming to {}", file_url);
     let (bucket, object) = parse_gs_url(file_url)?;
 
+    // Compute a running CRC32 sum.
+    let (stream, crc32c_reciever) = Crc32cStream::new(data);
+
+    // Post our data.
     let url = format!(
         "https://storage.googleapis.com/upload/storage/v1/b/{}/o",
         percent_encode(&bucket),
     );
     let query = UploadQuery {
         upload_type: "media",
-        name: object,
+        if_generation_match: 0,
+        name: object.clone(),
     };
     let client = Client::new(&ctx).await?;
     client
-        .post_stream(ctx.clone(), &url, query, idiomatic_bytes_stream(&ctx, data))
+        .post_stream(
+            ctx.clone(),
+            &url,
+            query,
+            idiomatic_bytes_stream(&ctx, stream.boxed()),
+        )
+        .await?;
+
+    // Wait for our computed hash code.
+    let hasher = crc32c_reciever
         .await
+        .map_err(|_| format_err!("error waiting for checksum"))?;
+    let crc32c = hasher.finish_encoded();
+
+    // Verify that our uploaded file has the right checksum.
+    let obj_url = format!(
+        "https://storage.googleapis.com/storage/v1/b/{}/o/{}",
+        percent_encode(&bucket),
+        percent_encode(&object),
+    );
+    let obj: StorageObject = client.get(ctx, &obj_url, NoQuery).await?;
+    if obj.crc32c == crc32c {
+        Ok(obj)
+    } else {
+        Err(format_err!(
+            "{} does not have the expected checksum, did it change?",
+            file_url,
+        ))
+    }
 }


### PR DESCRIPTION
We add support for the `ifGenerationMatch` parameter across our Google
Cloud Storage code. This allows us to (1) make sure nobody has created
a file behind our back mid-operation, and (2) make sure that nobody
has replaced a file we're using.

We also check CRC32C checksums on upload. Ideally, we'd do this on
download, too, but we haven't implemented that.

This code was part of an attempt to add support for streaming
composite uploads to Google Cloud Storage, but this involves several
annoying sub-problems that I don't want to get into before the 0.4.0
release.

There's some more composite-related code that isn't included in this
PR. (I may check it into a WIP branch.) This explains why a few APIs
appear to have been generalized slightly for no obvious reason.