### PR TITLE
s3: Require AWS_DEFAULT_REGION

### DIFF
--- a/dbcrossbarlib/src/clouds/aws/s3/mod.rs
+++ b/dbcrossbarlib/src/clouds/aws/s3/mod.rs
@@ -38,11 +38,7 @@ pub(self) async fn aws_s3_command() -> Result<Command> {
     } else {
         command.env_remove("AWS_SESSION_TOKEN");
     }
-    if let Some(region) = creds.get_optional("region") {
-        command.env("AWS_REGION", region);
-    } else {
-        command.env_remove("AWS_REGION");
-    }
+    command.env("AWS_DEFAULT_REGION", creds.get_required("default_region")?);
     command.arg("s3");
     Ok(command)
 }

--- a/dbcrossbarlib/src/credentials.rs
+++ b/dbcrossbarlib/src/credentials.rs
@@ -88,7 +88,7 @@ impl CredentialsManager {
             EnvMapping::required("access_key_id", "AWS_ACCESS_KEY_ID"),
             EnvMapping::required("secret_access_key", "AWS_SECRET_ACCESS_KEY"),
             EnvMapping::optional("session_token", "AWS_SESSION_TOKEN"),
-            EnvMapping::optional("region", "AWS_REGION"),
+            EnvMapping::required("default_region", "AWS_DEFAULT_REGION"),
         ]);
         sources.insert("aws".to_owned(), Mutex::new(aws.boxed()));
 

--- a/guide/src/s3.md
+++ b/guide/src/s3.md
@@ -17,10 +17,12 @@ At this point, we do not support single-file output to a cloud bucket. This is r
 
 ## Configuration & authentication
 
-The following environment variables are required:
+The following environment variables are used to authenticate:
 
-- `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`: Set these to your AWS credentials.
+- `AWS_ACCESS_KEY_ID` (required): The ID for your AWS credentials.
+- `AWS_SECRET_ACCESS_KEY` (required): The secret part of your AWS credentials.
 - `AWS_SESSION_TOKEN` (optional): Set this to use temporary AWS crdentials.
+- `AWS_DEFAULT_REGION` (required): Set this to your AWS region.
 
 ## Supported features
 


### PR DESCRIPTION
`aws s3` will actually default this in some (many? all?) cases, but I
couldn't find any documentation on the exact rules. So I'm going to make
this mandatory for now to avoid relying on unspecified behavior.