### PR TITLE
Add short argument names

### DIFF
--- a/dbcrossbar/tests/cli/cp/if_exists.rs
+++ b/dbcrossbar/tests/cli/cp/if_exists.rs
@@ -1,0 +1,111 @@
+//! Tests for `--if-exists` and related arguments.
+
+use cli_test_dir::*;
+use std::fs;
+
+use super::*;
+
+#[test]
+fn cp_if_exists_mutual_exclusion() {
+    let testdir = TestDir::new("dbcrossbar", "cp_if_exists_mutual_exclusion");
+    let src = testdir.src_path("fixtures/example.csv");
+    testdir
+        .cmd()
+        .arg("cp")
+        .arg("-F")
+        .arg("--if-exists=append")
+        .arg(&format!("csv:{}", src.display()))
+        .arg("csv:out.csv")
+        .expect_failure();
+}
+
+#[test]
+fn cp_if_exists_error() {
+    let testdir = TestDir::new("dbcrossbar", "cp_if_exists_error");
+    let src = testdir.src_path("fixtures/example.csv");
+    let expected = fs::read_to_string(&src).unwrap();
+    testdir
+        .cmd()
+        .arg("cp")
+        .arg(&format!("csv:{}", src.display()))
+        .arg("csv:out.csv")
+        .expect_success();
+
+    for &args in &[&["--if-exists=error"], &[][..]] {
+        testdir
+            .cmd()
+            .arg("cp")
+            .args(args)
+            .arg(&format!("csv:{}", src.display()))
+            .arg("csv:out.csv")
+            .expect_failure();
+    }
+
+    testdir.expect_file_contents("out.csv", &expected);
+}
+
+#[test]
+fn cp_if_exists_overwrite() {
+    let testdir = TestDir::new("dbcrossbar", "cp_if_exists_overwrite");
+    let src = testdir.src_path("fixtures/example.csv");
+    let expected = fs::read_to_string(&src).unwrap();
+
+    testdir
+        .cmd()
+        .arg("cp")
+        .arg(&format!("csv:{}", src.display()))
+        .arg("csv:out.csv")
+        .expect_success();
+
+    for &arg in &["--if-exists=overwrite", "-F"] {
+        testdir
+            .cmd()
+            .arg("cp")
+            .arg(arg)
+            .arg(&format!("csv:{}", src.display()))
+            .arg("csv:out.csv")
+            .expect_success();
+    }
+
+    testdir.expect_file_contents("out.csv", &expected);
+}
+
+#[test]
+#[ignore]
+fn cp_if_exists_append() {
+    let testdir = TestDir::new("dbcrossbar", "cp_if_exists_append");
+    let src = testdir.src_path("fixtures/example.csv");
+    let pg_table = post_test_table_url("cp_if_exists_append");
+
+    testdir
+        .cmd()
+        .arg("cp")
+        .arg(&format!("csv:{}", src.display()))
+        .arg(&pg_table)
+        .expect_success();
+
+    for &arg in &["--if-exists=append", "-A"] {
+        testdir
+            .cmd()
+            .arg("cp")
+            .arg(arg)
+            .arg(&format!("csv:{}", src.display()))
+            .arg(&pg_table)
+            .expect_success();
+    }
+
+    testdir
+        .cmd()
+        .arg("cp")
+        .arg(&pg_table)
+        .arg("csv:out.csv")
+        .expect_success();
+    let expected = r#"id,first_name,last_name
+1,John,Doe
+1,John,Doe
+1,John,Doe
+"#;
+    testdir.expect_file_contents("out.csv", expected);
+}
+
+// upsert-on is tested elsewhere.

--- a/dbcrossbar/tests/cli/cp/mod.rs
+++ b/dbcrossbar/tests/cli/cp/mod.rs
@@ -9,6 +9,7 @@ mod bigquery;
 mod combined;
 mod csv;
 mod gs;
+mod if_exists;
 mod postgres;
 mod redshift;
 mod s3;

--- a/dbcrossbar/tests/cli/cp/postgres.rs
+++ b/dbcrossbar/tests/cli/cp/postgres.rs
@@ -198,7 +198,9 @@ fn cp_pg_append_upsert_legacy_json() {
         .cmd()
         .args(&[
             "cp",
-            "--if-exists=upsert-on:id",
+            // Also test the short form of `--if-exists=upsert-on:id`.
+            "-U",
+            "id",
             &format!("--schema=postgres-sql:{}", schema.display()),
             &format!("csv:{}", src.display()),
             &pg_table,


### PR DESCRIPTION
I know that short argument names are officially discouraged at Faraday, but lots of people like them for interactive CLI use. Here are some proposed short forms included in this PR:

- `-s` => `--schema`
- `-F` => `--if-exists=overwrite`
- `-A` => `--if-exists=append`
- `-U` COLS => `--if-exists=upsert-on:COLS`

But before we start handling out short form arguments, we need to have a consistent plan.

Here are some other arguments which don't necessarily need a short form at this time, but which _might_ need them someday:

- Driver args
  - `--to-arg`
  - `--from-arg`
  - Arguments to temporary drivers when supported?
- `--temporary` (do we want to reserve `-t` or `-T`?)
- `--stream-size`