### PR TITLE
feat(postgres): added support for inet type

### DIFF
--- a/dbcrossbarlib/src/drivers/postgres_shared/catalog.rs
+++ b/dbcrossbarlib/src/drivers/postgres_shared/catalog.rs
@@ -241,6 +241,7 @@ fn pg_data_type(
                 Ok(PgScalarDataType::TimestampWithoutTimeZone)
             }
             "uuid" => Ok(PgScalarDataType::Uuid),
+            "inet" => Ok(PgScalarDataType::Inet),
             other => Err(format_err!("unknown data type {:?}", other)),
         }?;
         Ok(PgDataType::Scalar(ty))

--- a/dbcrossbarlib/src/drivers/postgres_shared/data_type.rs
+++ b/dbcrossbarlib/src/drivers/postgres_shared/data_type.rs
@@ -128,6 +128,7 @@ pub(crate) enum PgScalarDataType {
     TimestampWithoutTimeZone,
     TimestampWithTimeZone,
     Uuid,
+    Inet
 }
 
 impl PgScalarDataType {
@@ -181,6 +182,7 @@ impl PgScalarDataType {
                 Ok(DataType::TimestampWithTimeZone)
             }
             PgScalarDataType::Uuid => Ok(DataType::Uuid),
+            PgScalarDataType::Inet => Ok(DataType::Text)
         }
     }
 


### PR DESCRIPTION
While `inet` is recognized as its own postgres type (`PgScalarType::Inet`), it is just converted to `DataType::Text`, leaving a major TODO for preserving this type between databases that can handle it.