### PR TITLE
postgres: support array of varchar

### DIFF
--- a/dbcrossbarlib/src/drivers/postgres_shared/catalog.rs
+++ b/dbcrossbarlib/src/drivers/postgres_shared/catalog.rs
@@ -206,6 +206,7 @@ fn pg_data_type(
             "_timestamp" => PgScalarDataType::TimestampWithoutTimeZone,
             "_timestamptz" => PgScalarDataType::TimestampWithTimeZone,
             "_uuid" => PgScalarDataType::Uuid,
+            "_varchar" => PgScalarDataType::Text,
             _ => return Err(format_err!("unknown array element {:?}", udt_name)),
         };
         Ok(PgDataType::Array {
@@ -334,6 +335,10 @@ fn parsing_pg_data_type() {
         ),
         (
             ("ARRAY", "pg_catalog", "_text"),
+            array(PgScalarDataType::Text),
+        ),
+        (
+            ("ARRAY", "pg_catalog", "_varchar"),
             array(PgScalarDataType::Text),
         ),
         (


### PR DESCRIPTION
```
StandardError dbcrossbar cp failed pid 21 exit 1
app: dbcrossbar
 ver: 0.4.2-beta.6
Error: error reading schema from postgres://xxx
  caused by: unknown array element "_varchar"
```