### PR TITLE
redshift: Add "partner" comment support

### DIFF
--- a/dbcrossbar/tests/cli/cp/redshift.rs
+++ b/dbcrossbar/tests/cli/cp/redshift.rs
@@ -117,6 +117,10 @@ fn redshift_upsert() {
                 if_exists,
                 &format!("--temporary={}", s3_dir),
                 &format!("--schema=postgres-sql:{}", schema.display()),
+                concat!(
+                    "--to-arg=partner=dbcrossbar test v",
+                    env!("CARGO_PKG_VERSION")
+                ),
                 &format!("--to-arg=iam_role={}", iam_role),
                 &format!("--to-arg=region={}", region),
                 &format!("csv:{}", src.display()),
@@ -135,6 +139,10 @@ fn redshift_upsert() {
             &format!("--temporary={}", s3_dir),
             &format!("--from-arg=iam_role={}", iam_role),
             &format!("--from-arg=region={}", region),
+            concat!(
+                "--from-arg=partner=dbcrossbar test v",
+                env!("CARGO_PKG_VERSION")
+            ),
             &redshift_table,
             "csv:out.csv",
         ])

--- a/guide/src/redshift.md
+++ b/guide/src/redshift.md
@@ -1,6 +1,6 @@
 # RedShift
 
-Amazon's [Redshift](https://aws.amazon.com/redshift/) is a cloud-based data warehouse designed to support analytical queries. This driver receives less testing than our BigQuery driver, because the cheapest possible RedShift test system costs over $100/month. Sponsors are welcome!
+Amazon's [Redshift](https://aws.amazon.com/redshift/) is a cloud-based data warehouse designed to support analytical queries. This driver receives less testing than our BigQuery driver, because the cheapest possible RedShift test system costs over \$100/month. Sponsors are welcome!
 
 ## Example locators
 
@@ -27,6 +27,10 @@ The following `--temporary` flag is required:
 - `--to-arg=region=$REGION`
 
 This may require some experimentation.
+
+If you need to generate "-- partner:" SQL comments for an AWS RedShift partner program, you can do it as follows:
+
+- `--to-arg=partner="myapp v1.0"`
 
 [copyauth]: https://docs.aws.amazon.com/redshift/latest/dg/loading-data-access-permissions.html
 


### PR DESCRIPTION
Users who are participating in the RedShift partner program need to be
able to generate specially-formatted comments in SQL queries.
