### PR TITLE
bigml: Fix `one-of` to map to categorical value

### DIFF
--- a/dbcrossbarlib/src/clouds/gcloud/bigquery/jobs.rs
+++ b/dbcrossbarlib/src/clouds/gcloud/bigquery/jobs.rs
@@ -85,10 +85,9 @@ impl Job {
 
     /// Get the job ID, with the project and region prefixes stripped.
     pub(crate) fn reference(&self) -> Result<&JobReference> {
-        Ok(self
-            .job_reference
+        self.job_reference
             .as_ref()
-            .ok_or_else(|| format_err!("newly created job has no jobReference"))?)
+            .ok_or_else(|| format_err!("newly created job has no jobReference"))
     }
 
     /// Get a URL which can be used for this job.

--- a/dbcrossbarlib/src/drivers/bigquery_shared/column_name.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/column_name.rs
@@ -163,7 +163,7 @@ impl<'de> Deserialize<'de> for ColumnName {
         D: Deserializer<'de>,
     {
         let s: &str = Deserialize::deserialize(deserializer)?;
-        Ok(ColumnName::try_from(s).map_err(de::Error::custom)?)
+        ColumnName::try_from(s).map_err(de::Error::custom)
     }
 }
 

--- a/guide/src/bigml.md
+++ b/guide/src/bigml.md
@@ -35,7 +35,7 @@ You'll also need to pass the following on the command line when using:
 You can also specify the following `--to-arg` values:
 
 - `name`: The human-readable name of the resource to create.
-- `optype_for_text`: The BigML optype to use for text fields. This defaults to `text`. You may want to set it to `categorical` if your text fields contain a small set of fixed strings.
+- `optype_for_text`: The BigML optype to use for text fields. This defaults to `text`. You may want to set it to `categorical` if your text fields contain a small set of fixed strings. But you should probably use `dbcrossbar`'s `{ "one_of": string_list }` types instead, which will always map to `categorical`.
 - `tag`: This may be specified repeatedly to attach tags to the created resources.
 
 ## Supported features


### PR DESCRIPTION
String enumerations should always map to BigML categorical values.

Co-authored-by: Tom Caruso <tom@tcaruso.com>
