### PR TITLE
bigquery: Retry `extract` after `accessDenied`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) for the `dbcrossbar` CLI tool. (The `dbcrossbarlib` crate is an internal-only dependency with no versioning policy at this time.)
 
+## [Unreleased]
+
+### Fixed
+
+- bigquery: Retry `extract` operations after `accessDenied` errors. These errors sometimes occur even when BigQuery _should_ have the necessary access permissions. This may be caused by a permissions race condition somewhere in Google Cloud?
+
 ## [0.5.0-beta.2] - 2021-12-19
 
 ### Changed


### PR DESCRIPTION
This appears to be a transient error caused by an authorization race
condition in Google Cloud.

Fixes #181.
