### PR TITLE
gs: Retry deletes which fail with 403

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) for the `dbcrossbar` CLI tool. (The `dbcrossbarlib` crate is an internal-only dependency with no versioning policy at this time.)
 
+## [Unreleased]
+
+### Fixed
+
+- gs: Retry `delete` operations after 403 Forbidden errors. This appears to be part of the same hypothesized permissions race that affected `extract` in v0.5.0-beta.3.
+
 ## [0.5.0-beta.3] - 2021-12-31
 
 ### Fixed

--- a/dbcrossbarlib/src/clouds/gcloud/client.rs
+++ b/dbcrossbarlib/src/clouds/gcloud/client.rs
@@ -404,3 +404,16 @@ pub(crate) fn response_claims_to_be_json(http_resp: &reqwest::Response) -> bool 
     content_type_mime.type_() == mime::APPLICATION
         && content_type_mime.subtype() == mime::JSON
 }
+
+/// Given an `Error`, look to see if it's a wrapper around `reqwest::Error`, and
+/// if so, return the original error. Otherwise return `None`.
+pub(crate) fn original_http_error(err: &Error) -> Option<&reqwest::Error> {
+    // Walk the chain of all errors, ending with the original root cause.
+    for cause in err.chain() {
+        // If this error is a `reqwest::Error`, return it.
+        if let Some(reqwest_error) = cause.downcast_ref::<reqwest::Error>() {
+            return Some(reqwest_error);
+        }
+    }
+    None
+}


### PR DESCRIPTION
Another attempt at dealing with the mysterious "access denied" errors
from Google Cloud Storage that appear transiently, but only for writes.

Fixes #181. Again. Maybe.
