### PR TITLE
Add new `bigquery-test-fixture` schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,9 +1524,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2074,9 +2074,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
 ]

--- a/dbcrossbar/tests/cli/cp/bigquery.rs
+++ b/dbcrossbar/tests/cli/cp/bigquery.rs
@@ -12,8 +12,8 @@ use super::*;
 #[test]
 #[ignore]
 fn cp_from_bigquery_to_exact_csv() {
-    let pg_table = bq_test_table("cp_from_bigquery_to_exact_csv");
-    assert_cp_to_exact_csv("cp_from_bigquery_to_exact_csv", &pg_table);
+    let bq_table = bq_test_table("cp_from_bigquery_to_exact_csv");
+    assert_cp_to_exact_csv("cp_from_bigquery_to_exact_csv", &bq_table);
 }
 
 #[test]

--- a/dbcrossbar/tests/cli/cp/bigquery_test_fixture.rs
+++ b/dbcrossbar/tests/cli/cp/bigquery_test_fixture.rs
@@ -1,0 +1,54 @@
+//! BigQuery-test-fixture specific tests.
+
+use super::*;
+
+#[test]
+#[ignore]
+fn cp_from_bigquery_test_fixture_to_exact_csv() {
+    let bq_table = bq_test_table("cp_from_bigquery_test_fixture_to_exact_csv")
+        .replace("bigquery:", "bigquery-test-fixture:");
+    assert_cp_to_exact_csv("cp_from_bigquery_test_fixture_to_exact_csv", &bq_table);
+}
+
+#[test]
+#[ignore]
+fn cp_csv_to_bigquery_test_fixture_to_csv() {
+    let testdir = TestDir::new("dbcrossbar", "cp_csv_to_bigquery_test_fixture_to_csv");
+    let src = testdir.src_path("fixtures/many_types.csv");
+    let schema = testdir.src_path("fixtures/many_types.sql");
+    let bq_temp_ds = bq_temp_dataset();
+    let gs_temp_dir = gs_test_dir_url("cp_csv_to_bigquery_test_fixture_to_csv");
+    let bq_table = bq_test_table("cp_csv_to_bigquery_test_fixture_to_csv")
+        .replace("bigquery:", "bigquery-test-fixture:");
+
+    // CSV to BigQuery.
+    testdir
+        .cmd()
+        .args(&[
+            "cp",
+            "--if-exists=overwrite",
+            &format!("--temporary={}", gs_temp_dir),
+            &format!("--temporary={}", bq_temp_ds),
+            &format!("--schema=postgres-sql:{}", schema.display()),
+            "--to-arg=job_labels[dbcrossbar_test]=true",
+            &format!("csv:{}", src.display()),
+            &bq_table,
+        ])
+        .tee_output()
+        .expect_success();
+
+    // BigQuery to CSV.
+    testdir
+        .cmd()
+        .args(&[
+            "cp",
+            "--if-exists=overwrite",
+            &format!("--temporary={}", gs_temp_dir),
+            &format!("--temporary={}", bq_temp_ds),
+            "--from-arg=job_labels[dbcrossbar_test]=true",
+            &bq_table,
+            "csv:out/",
+        ])
+        .tee_output()
+        .expect_success();
+}

--- a/dbcrossbar/tests/cli/cp/mod.rs
+++ b/dbcrossbar/tests/cli/cp/mod.rs
@@ -6,6 +6,7 @@ use std::{env, fs};
 
 mod bigml;
 mod bigquery;
+mod bigquery_test_fixture;
 mod combined;
 mod csv;
 mod gs;

--- a/dbcrossbarlib/Cargo.toml
+++ b/dbcrossbarlib/Cargo.toml
@@ -49,7 +49,7 @@ peg = "0.7.0"
 percent-encoding = "2.1.0"
 postgis = "0.9.0"
 rand = "0.8.1"
-regex = "1.1.0"
+regex = "1.5.4"
 reqwest = { version = "0.11.0", default-features = false, features = ["rustls-tls-native-roots", "json", "stream"] }
 rustls = "0.20.1"
 rustls-native-certs = "0.6.1"

--- a/dbcrossbarlib/src/clouds/gcloud/bigquery/mod.rs
+++ b/dbcrossbarlib/src/clouds/gcloud/bigquery/mod.rs
@@ -11,12 +11,14 @@ pub(crate) mod jobs;
 mod load;
 mod queries;
 mod schema;
+mod tables;
 
 pub(crate) use extract::*;
 pub(crate) use jobs::Labels;
 pub(crate) use load::*;
 pub(crate) use queries::*;
 pub(crate) use schema::*;
+pub(crate) use tables::*;
 
 /// A BigQuery error.
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/dbcrossbarlib/src/clouds/gcloud/bigquery/tables.rs
+++ b/dbcrossbarlib/src/clouds/gcloud/bigquery/tables.rs
@@ -1,0 +1,75 @@
+//! Support for looking up BigQuery schemas.
+
+use serde::{Deserialize, Serialize};
+
+use super::super::{percent_encode, Client, NoQuery};
+use super::jobs::TableReference;
+use crate::clouds::gcloud::ClientError;
+use crate::common::*;
+use crate::drivers::bigquery_shared::TableName;
+
+/// Delete the specified table.
+#[instrument(level = "trace")]
+pub(crate) async fn delete_table(name: &TableName, not_found_ok: bool) -> Result<()> {
+    let url = format!(
+        "https://bigquery.googleapis.com/bigquery/v2/projects/{}/datasets/{}/tables/{}",
+        percent_encode(name.project()),
+        percent_encode(name.dataset()),
+        percent_encode(name.table()),
+    );
+
+    // Delete the specified table.
+    let client = Client::new().await?;
+    match client.delete(&url, NoQuery).await {
+        Ok(_) => Ok(()),
+        Err(ClientError::NotFound { .. }) if not_found_ok => Ok(()),
+        Err(ClientError::Other(err)) => Err(err),
+        Err(err) => Err(err.into()),
+    }
+}
+
+/// Information needed to create a view.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TableViewNew<'a> {
+    table_reference: TableReference,
+    view: ViewDefintion<'a>,
+}
+
+/// View details for BigQuery.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ViewDefintion<'a> {
+    query: &'a str,
+    use_legacy_sql: bool,
+}
+
+/// Our response type. We don't care about what's in here.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Table {}
+
+/// Create a view using the specied table name and SQL.
+#[instrument(level = "trace")]
+pub(crate) async fn create_view(name: &TableName, view_sql: &str) -> Result<()> {
+    // Build our URL.
+    let url = format!(
+        "https://bigquery.googleapis.com/bigquery/v2/projects/{}/datasets/{}/tables",
+        percent_encode(name.project()),
+        percent_encode(name.dataset()),
+    );
+
+    // Build our request body.
+    let table = TableViewNew {
+        table_reference: TableReference::from(name),
+        view: ViewDefintion {
+            query: view_sql,
+            use_legacy_sql: false,
+        },
+    };
+
+    // Create our view.
+    let client = Client::new().await?;
+    client.post::<Table, _, _, _>(&url, NoQuery, table).await?;
+    Ok(())
+}

--- a/dbcrossbarlib/src/csv_stream.rs
+++ b/dbcrossbarlib/src/csv_stream.rs
@@ -17,7 +17,6 @@ pub struct CsvStream {
 
 impl CsvStream {
     /// Construct a CSV stream from bytes.
-    #[cfg(test)]
     pub(crate) async fn from_bytes<B>(bytes: B) -> Self
     where
         B: Into<BytesMut>,
@@ -35,7 +34,6 @@ impl CsvStream {
     }
 
     /// Receive all data on a CSV stream and return it as bytes.
-    #[cfg(test)]
     #[instrument(level = "trace", skip(self))]
     pub(crate) async fn into_bytes(self) -> Result<BytesMut> {
         let mut stream = self.data;

--- a/dbcrossbarlib/src/drivers/bigquery_shared/mod.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/mod.rs
@@ -20,6 +20,7 @@ mod indent_level;
 mod schema;
 mod table;
 mod table_name;
+mod write_bigquery_sql;
 
 pub(crate) use self::column::*;
 pub(crate) use self::column_name::*;
@@ -28,3 +29,4 @@ pub(crate) use self::driver_args::*;
 pub(crate) use self::schema::*;
 pub(crate) use self::table::*;
 pub(crate) use self::table_name::*;
+pub(crate) use self::write_bigquery_sql::*;

--- a/dbcrossbarlib/src/drivers/bigquery_shared/write_bigquery_sql.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/write_bigquery_sql.rs
@@ -1,0 +1,137 @@
+use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
+
+use crate::common::*;
+
+/// Implemented by types that can be written to BigQuery SQL.
+pub(crate) trait WriteBigQuerySql<W: Write> {
+    /// Write `self` to `wtr` as a BigQuery SQL literal.
+    fn write_bigquery_sql(&self, sql: &mut W) -> Result<(), io::Error>;
+}
+
+impl<W: Write> WriteBigQuerySql<W> for bool {
+    fn write_bigquery_sql(&self, sql: &mut W) -> Result<(), io::Error> {
+        if *self {
+            write!(sql, "TRUE")
+        } else {
+            write!(sql, "FALSE")
+        }
+    }
+}
+
+impl<W: Write> WriteBigQuerySql<W> for &'_ str {
+    fn write_bigquery_sql(&self, sql: &mut W) -> Result<(), io::Error> {
+        // I _think_ this is correct. See
+        // https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#string_and_bytes_literals
+        write!(sql, "'")?;
+        for c in self.chars() {
+            match c {
+                '\'' | '\\' => write!(sql, "\\{}", c),
+                '\r' => write!(sql, "\\r"),
+                '\n' => write!(sql, "\\n"),
+                _ if c.is_ascii_graphic() => write!(sql, "{}", c),
+                _ => write!(sql, "\\U{:08x}", u32::from(c)),
+            }?;
+        }
+        write!(sql, "'")?;
+        Ok(())
+    }
+}
+
+/// Convenience wrapper to write a `&str` as a byte literal. We use this instead
+/// of `&[u8]` because our data is already known to be `&str`.
+pub(crate) struct BytesLiteral<'a>(pub(crate) &'a str);
+
+impl<'a, W: Write> WriteBigQuerySql<W> for BytesLiteral<'a> {
+    fn write_bigquery_sql(&self, sql: &mut W) -> Result<(), io::Error> {
+        write!(sql, "B")?;
+        self.0.write_bigquery_sql(sql)
+    }
+}
+
+impl<W: Write> WriteBigQuerySql<W> for f64 {
+    fn write_bigquery_sql(&self, sql: &mut W) -> Result<(), io::Error> {
+        write!(sql, "{}", *self)
+    }
+}
+
+pub(crate) struct ExpNotation(pub f64);
+
+impl<W: Write> WriteBigQuerySql<W> for ExpNotation {
+    fn write_bigquery_sql(&self, sql: &mut W) -> Result<(), io::Error> {
+        write!(sql, "{:e}", self.0)
+    }
+}
+
+impl<W: Write> WriteBigQuerySql<W> for i64 {
+    fn write_bigquery_sql(&self, sql: &mut W) -> Result<(), io::Error> {
+        write!(sql, "{}", *self)
+    }
+}
+
+/// Convenience wrapper to write a `&str` as a NUMERIC literal.
+pub(crate) struct NumericLiteral<'a>(pub(crate) &'a str);
+
+impl<'a, W: Write> WriteBigQuerySql<W> for NumericLiteral<'a> {
+    fn write_bigquery_sql(&self, sql: &mut W) -> Result<(), io::Error> {
+        write!(sql, "NUMERIC ")?;
+        self.0.write_bigquery_sql(sql)
+    }
+}
+
+// Geography literals need to be wrapped in ST_GEOGFROMGEOJSON.
+pub(crate) struct GeographyLiteral<'a>(pub(crate) &'a str);
+
+impl<'a, W: Write> WriteBigQuerySql<W> for GeographyLiteral<'a> {
+    fn write_bigquery_sql(&self, sql: &mut W) -> Result<(), io::Error> {
+        write!(sql, "ST_GEOGFROMGEOJSON(")?;
+        self.0.write_bigquery_sql(sql)?;
+        write!(sql, ")")
+    }
+}
+
+impl<'a, W: Write, Elem: WriteBigQuerySql<W>> WriteBigQuerySql<W> for &'a [Elem] {
+    fn write_bigquery_sql(&self, sql: &mut W) -> Result<(), io::Error> {
+        // TODO: Remember, `ARRAY[ARRAY[...]]` does not work! We need to
+        // generate `ARRAY[STRUCT(ARRAY[...])]`.
+        write!(sql, "ARRAY[")?;
+        for (idx, elem) in self.iter().enumerate() {
+            if idx != 0 {
+                write!(sql, ",")?;
+            }
+            elem.write_bigquery_sql(sql)?;
+        }
+        write!(sql, "]")
+    }
+}
+
+impl<W: Write> WriteBigQuerySql<W> for NaiveDate {
+    fn write_bigquery_sql(&self, sql: &mut W) -> Result<(), io::Error> {
+        // BigQuery: DATETIME 'YYYY-[M]M-[D]D'
+        // Rust Chrono: https://docs.rs/chrono/latest/chrono/format/strftime/index.html
+        write!(sql, "DATE '{}'", self.format("%Y-%m-%d"))
+    }
+}
+
+impl<W: Write> WriteBigQuerySql<W> for NaiveDateTime {
+    fn write_bigquery_sql(&self, sql: &mut W) -> Result<(), io::Error> {
+        // BigQuery: DATETIME 'YYYY-[M]M-[D]D( |T)[[H]H:[M]M:[S]S[.DDDDDD]]'
+        // Rust Chrono: https://docs.rs/chrono/latest/chrono/format/strftime/index.html
+        write!(sql, "DATETIME '{}'", self.format("%Y-%m-%dT%H:%M:%S%.f"))
+    }
+}
+
+impl<W: Write> WriteBigQuerySql<W> for DateTime<Utc> {
+    fn write_bigquery_sql(&self, sql: &mut W) -> Result<(), io::Error> {
+        // BigQuery: TIMESTAMP 'YYYY-[M]M-[D]D[( |T)[H]H:[M]M:[S]S[.F]]
+        // [time_zone]'
+        // (but time_zone can be an offset instead).
+        //
+        // Rust Chrono:
+        // https://docs.rs/chrono/latest/chrono/format/strftime/index.html
+        write!(
+            sql,
+            "TIMESTAMP '{}'",
+            self.format("%Y-%m-%dT%H:%M:%S%.f%:z")
+        )
+    }
+}

--- a/dbcrossbarlib/src/drivers/bigquery_test_fixture/mod.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_test_fixture/mod.rs
@@ -1,0 +1,412 @@
+//! Driver for working with CSV files.
+
+use std::{fmt, io::Cursor, str::FromStr};
+
+use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
+
+use crate::{
+    clouds::gcloud::bigquery,
+    common::*,
+    concat::concatenate_csv_streams,
+    drivers::bigquery_shared::{BqTable, Usage},
+    from_csv_cell::FromCsvCell,
+    from_json_value::FromJsonValue,
+};
+
+use super::{
+    bigquery::BigQueryLocator,
+    bigquery_shared::{
+        BqDataType, BqNonArrayDataType, BytesLiteral, ExpNotation, GeographyLiteral,
+        NumericLiteral, WriteBigQuerySql,
+    },
+};
+
+/// The maximum allowable CSV file size for us to try the "VIEW" trick.
+const MAX_CSV_SIZE_FOR_VIEW: usize = u16::MAX as usize;
+
+/// A version of `BigQueryLocator` which is optimized for creating small,
+/// read-only "tables" using various tricks. This should normally be used to
+/// create input "tables" for BigQuery SQL testing.
+///
+/// It does sneaky things like building views with built-in data. But it creates
+/// those views 13-15x faster than we can create real BigQuery tables.
+#[derive(Clone, Debug)]
+pub(crate) struct BigQueryTestFixtureLocator {
+    /// A wrapped `BigQueryLocator`, which we'll defer many operations to.
+    bigquery: BigQueryLocator,
+}
+
+impl fmt::Display for BigQueryTestFixtureLocator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "bigquery-test-fixture:{}", self.bigquery.as_table_name())
+    }
+}
+
+impl FromStr for BigQueryTestFixtureLocator {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let as_bigquery = s.replace(
+            BigQueryTestFixtureLocator::scheme(),
+            BigQueryLocator::scheme(),
+        );
+        Ok(BigQueryTestFixtureLocator {
+            bigquery: BigQueryLocator::from_str(&as_bigquery)?,
+        })
+    }
+}
+
+impl Locator for BigQueryTestFixtureLocator {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self, ctx: Context) -> BoxFuture<Option<Schema>> {
+        self.bigquery.schema(ctx)
+    }
+
+    fn count(
+        &self,
+        ctx: Context,
+        shared_args: SharedArguments<Unverified>,
+        source_args: SourceArguments<Unverified>,
+    ) -> BoxFuture<usize> {
+        self.bigquery.count(ctx, shared_args, source_args)
+    }
+
+    fn local_data(
+        &self,
+        ctx: Context,
+        shared_args: SharedArguments<Unverified>,
+        source_args: SourceArguments<Unverified>,
+    ) -> BoxFuture<Option<BoxStream<CsvStream>>> {
+        self.bigquery.local_data(ctx, shared_args, source_args)
+    }
+
+    fn display_output_locators(&self) -> DisplayOutputLocators {
+        self.bigquery.display_output_locators()
+    }
+
+    fn write_local_data(
+        &self,
+        ctx: Context,
+        data: BoxStream<CsvStream>,
+        shared_args: SharedArguments<Unverified>,
+        dest_args: DestinationArguments<Unverified>,
+    ) -> BoxFuture<BoxStream<BoxFuture<BoxLocator>>> {
+        write_local_data_helper(ctx, self.to_owned(), data, shared_args, dest_args)
+            .boxed()
+    }
+
+    fn supports_write_remote_data(&self, source: &dyn Locator) -> bool {
+        self.bigquery.supports_write_remote_data(source)
+    }
+
+    fn write_remote_data(
+        &self,
+        ctx: Context,
+        source: BoxLocator,
+        shared_args: SharedArguments<Unverified>,
+        source_args: SourceArguments<Unverified>,
+        dest_args: DestinationArguments<Unverified>,
+    ) -> BoxFuture<Vec<BoxLocator>> {
+        self.bigquery.write_remote_data(
+            ctx,
+            source,
+            shared_args,
+            source_args,
+            dest_args,
+        )
+    }
+}
+
+/// Cached type information about a column.
+struct BqColumnTypeInfo {
+    is_not_null: bool,
+    bq_data_type: BqDataType,
+}
+
+/// Actual implementation of `write_local_data
+#[instrument(
+    level = "debug",
+    name = "bigquery_test_fixture::write_local_data",
+    skip_all,
+    fields(dest = %dest)
+)]
+async fn write_local_data_helper(
+    ctx: Context,
+    dest: BigQueryTestFixtureLocator,
+    data: BoxStream<CsvStream>,
+    shared_args: SharedArguments<Unverified>,
+    dest_args: DestinationArguments<Unverified>,
+) -> Result<BoxStream<BoxFuture<BoxLocator>>> {
+    // Concatenate all our CSV streams together, removing duplicate headers.
+    let csv_stream = concatenate_csv_streams(ctx.clone(), data)?;
+    let csv_data = csv_stream.into_bytes().await?;
+
+    // Check our data size. If it's too big, fall back to our regular BigQuery
+    // driver. (Assuming we didn't already crash by trying to read a 60 GB CSV
+    // file into RAM!)
+    if csv_data.len() > MAX_CSV_SIZE_FOR_VIEW {
+        debug!(
+            "bigquery-test-fixture data is too big ({} bytes), loading the slow way",
+            csv_data.len()
+        );
+        let csv_stream = CsvStream::from_bytes(csv_data).await;
+        let data = box_stream_once(Ok(csv_stream));
+        return dest
+            .bigquery
+            .write_local_data(ctx, data, shared_args, dest_args)
+            .await;
+    }
+
+    // Validate our driver arguments.
+    let shared_args = shared_args.verify(BigQueryTestFixtureLocator::features())?;
+    let dest_args = dest_args.verify(BigQueryTestFixtureLocator::features())?;
+
+    // Make sure we're in a supported `--if-exists` mode.
+    let if_exists = dest_args.if_exists();
+
+    // Get our BigQuery table.
+    let schema = shared_args.schema();
+    let bq_table = BqTable::for_table_name_and_columns(
+        schema,
+        dest.bigquery.as_table_name().to_owned(),
+        &schema.table.columns,
+        Usage::FinalTable,
+    )?;
+
+    // Collect our bq_data_types for each column.
+    let bq_col_type_infos = bq_table
+        .columns
+        .iter()
+        .map(|c| {
+            Ok(BqColumnTypeInfo {
+                is_not_null: c.is_not_null(),
+                bq_data_type: c.bq_data_type()?,
+            })
+        })
+        .collect::<Result<Vec<BqColumnTypeInfo>>>()?;
+
+    // Generate SQL header.
+    let mut sql = vec![];
+    writeln!(&mut sql, "SELECT * FROM UNNEST(ARRAY<STRUCT<")?;
+    for (idx, (col, bq_col_type_info)) in
+        bq_table.columns.iter().zip(&bq_col_type_infos).enumerate()
+    {
+        separator_comma(&mut sql, idx)?;
+        writeln!(
+            &mut sql,
+            "{} {}",
+            col.name.quoted(),
+            bq_col_type_info.bq_data_type
+        )?;
+    }
+    writeln!(&mut sql, ">>[")?;
+
+    // Read CSV rows and copy data into SQL body.
+    let mut rdr = csv::Reader::from_reader(Cursor::new(&*csv_data));
+    for (row_idx, row) in rdr.records().enumerate() {
+        let row = row?;
+        separator_comma(&mut sql, row_idx)?;
+        write!(&mut sql, "(")?;
+        for (col_idx, (bq_col_type_info, cell)) in
+            bq_col_type_infos.iter().zip(row.into_iter()).enumerate()
+        {
+            separator_comma(&mut sql, col_idx)?;
+            write_csv_cell_as_bigquery_literal(&mut sql, bq_col_type_info, cell)?;
+        }
+        writeln!(&mut sql, ")")?;
+    }
+    writeln!(&mut sql, "])")?;
+    let sql =
+        String::from_utf8(sql).context("CREATE VIEW SQL contained non-UTF-8 data")?;
+
+    // Create our view. Using `bigquery::execute_query` would need to create a
+    // batch job, which takes a minimum of about 2 seconds. Using
+    // `bigquery::delete_table` and `bigquery::create_view` gets it down under
+    // 0.7 seconds.
+    debug!("import sql: {}", sql);
+    if if_exists == &IfExists::Overwrite {
+        bigquery::delete_table(dest.bigquery.as_table_name(), true).await?;
+    }
+    bigquery::create_view(dest.bigquery.as_table_name(), &sql).await?;
+
+    // We don't need any parallelism after the BigQuery step, so just return
+    // a stream containing a single future.
+    let fut = async { Ok(dest.boxed()) }.boxed();
+    Ok(box_stream_once(Ok(fut)))
+}
+
+/// Write a comma, but only if `idx` is not 0.
+fn separator_comma<W: Write>(wtr: &mut W, idx: usize) -> Result<(), io::Error> {
+    if idx != 0 {
+        write!(wtr, ",")?;
+    }
+    Ok(())
+}
+
+/// Parse a CSV cell and write it as a BigQuery literal SQL value.
+fn write_csv_cell_as_bigquery_literal<W: Write>(
+    sql: &mut W,
+    bq_col_type_info: &BqColumnTypeInfo,
+    cell: &str,
+) -> Result<()> {
+    match &bq_col_type_info.bq_data_type {
+        BqDataType::Array(elem_ty) => {
+            let json = serde_json::Value::from_csv_cell(cell)?;
+            if let serde_json::Value::Array(arr) = json {
+                write!(sql, "[")?;
+                for (idx, json) in arr.into_iter().enumerate() {
+                    separator_comma(sql, idx)?;
+                    write_json_value_as_bigquery_literal(elem_ty, &json, sql)?;
+                }
+                write!(sql, "]")?;
+            } else {
+                return Err(format_err!("expected JSON array, found {:?}", cell));
+            }
+        }
+        BqDataType::NonArray(ty) => {
+            // If this column is nullable, and the cell is empty, always make it
+            // `NULL`. This matches the behavior of BigQuery's native CSV
+            // import, as well as our own `BigQueryLocator` driver. For example,
+            // see https://stackoverflow.com/q/38014288/12089.
+            if !bq_col_type_info.is_not_null && cell.is_empty() {
+                write!(sql, "NULL")?;
+                return Ok(());
+            }
+
+            match ty {
+                BqNonArrayDataType::Bool => {
+                    let value: bool = FromCsvCell::from_csv_cell(cell)?;
+                    value.write_bigquery_sql(sql)?;
+                }
+                BqNonArrayDataType::Bytes => {
+                    BytesLiteral(cell).write_bigquery_sql(sql)?;
+                }
+                BqNonArrayDataType::Date => {
+                    let value: NaiveDate = FromCsvCell::from_csv_cell(cell)?;
+                    value.write_bigquery_sql(sql)?;
+                }
+                BqNonArrayDataType::Datetime => {
+                    let value: NaiveDateTime = FromCsvCell::from_csv_cell(cell)?;
+                    value.write_bigquery_sql(sql)?;
+                }
+                BqNonArrayDataType::Float64 => {
+                    let value: f64 = FromCsvCell::from_csv_cell(cell)?;
+                    // BigQuery will accept `1e37`, but not "1" followed by 37 zeroes.
+                    // Go figure.
+                    ExpNotation(value).write_bigquery_sql(sql)?;
+                }
+                BqNonArrayDataType::Geography => {
+                    GeographyLiteral(cell).write_bigquery_sql(sql)?;
+                }
+                BqNonArrayDataType::Int64 => {
+                    let value: i64 = FromCsvCell::from_csv_cell(cell)?;
+                    value.write_bigquery_sql(sql)?;
+                }
+                BqNonArrayDataType::Numeric => {
+                    NumericLiteral(cell).write_bigquery_sql(sql)?;
+                }
+                BqNonArrayDataType::String | BqNonArrayDataType::Stringified(_) => {
+                    cell.write_bigquery_sql(sql)?;
+                }
+                BqNonArrayDataType::Timestamp => {
+                    let value: DateTime<Utc> = FromCsvCell::from_csv_cell(cell)?;
+                    value.write_bigquery_sql(sql)?;
+                }
+                // Time types cannot occur naturally in the current dbcrossbar
+                // interchange types. Structs do occur, and we could support
+                // them, but we haven't done the work yet.
+                BqNonArrayDataType::Time | BqNonArrayDataType::Struct(_) => {
+                    return Err(format_err!(
+                        "cannot ingest data of type {} using {}, use {} instead",
+                        ty,
+                        BigQueryTestFixtureLocator::scheme(),
+                        BigQueryLocator::scheme(),
+                    ));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Take a `serde_json::Value` and write it out as a BigQuery SQL literal. We
+/// use this to handle elements in array literals.
+fn write_json_value_as_bigquery_literal<W: Write>(
+    elem_ty: &BqNonArrayDataType,
+    json: &serde_json::Value,
+    sql: &mut W,
+) -> Result<()> {
+    match elem_ty {
+        BqNonArrayDataType::Bool => {
+            let value: bool = FromJsonValue::from_json_value(json)?;
+            value.write_bigquery_sql(sql)?;
+        }
+        BqNonArrayDataType::Bytes => {
+            let value: String = FromJsonValue::from_json_value(json)?;
+            BytesLiteral(&value).write_bigquery_sql(sql)?;
+        }
+        BqNonArrayDataType::Date => {
+            let value: NaiveDate = FromJsonValue::from_json_value(json)?;
+            value.write_bigquery_sql(sql)?;
+        }
+        BqNonArrayDataType::Datetime => {
+            let value: NaiveDateTime = FromJsonValue::from_json_value(json)?;
+            value.write_bigquery_sql(sql)?;
+        }
+        BqNonArrayDataType::Float64 => {
+            let value: f64 = FromJsonValue::from_json_value(json)?;
+            // BigQuery will accept `1e37`, but not "1" followed by 37 zeroes.
+            // Go figure.
+            ExpNotation(value).write_bigquery_sql(sql)?;
+        }
+        BqNonArrayDataType::Geography => {
+            let value: String = FromJsonValue::from_json_value(json)?;
+            GeographyLiteral(&value).write_bigquery_sql(sql)?;
+        }
+        BqNonArrayDataType::Int64 => {
+            let value: i64 = FromJsonValue::from_json_value(json)?;
+            value.write_bigquery_sql(sql)?;
+        }
+        BqNonArrayDataType::Numeric => {
+            let value: String = FromJsonValue::from_json_value(json)?;
+            NumericLiteral(&value).write_bigquery_sql(sql)?;
+        }
+        BqNonArrayDataType::String | BqNonArrayDataType::Stringified(_) => {
+            let value: String = FromJsonValue::from_json_value(json)?;
+            (&value[..]).write_bigquery_sql(sql)?;
+        }
+        BqNonArrayDataType::Timestamp => {
+            let value: DateTime<Utc> = FromJsonValue::from_json_value(json)?;
+            value.write_bigquery_sql(sql)?;
+        }
+        // Time types cannot occur naturally in the current dbcrossbar
+        // interchange types. Structs do occur, and we could support
+        // them, but we haven't done the work yet.
+        BqNonArrayDataType::Time | BqNonArrayDataType::Struct(_) => {
+            return Err(format_err!(
+                "cannot ingest data of type {} using {}, use {} instead",
+                elem_ty,
+                BigQueryTestFixtureLocator::scheme(),
+                BigQueryLocator::scheme(),
+            ));
+        }
+    };
+    Ok(())
+}
+
+impl LocatorStatic for BigQueryTestFixtureLocator {
+    fn scheme() -> &'static str {
+        "bigquery-test-fixture:"
+    }
+
+    fn features() -> Features {
+        // We suppor the same features as BigQuery, except our `--if-exists`
+        // options are a lot more limited.
+        let mut result = BigQueryLocator::features();
+        result.dest_if_exists = IfExistsFeatures::Overwrite | IfExistsFeatures::Error;
+        result
+    }
+}

--- a/dbcrossbarlib/src/drivers/mod.rs
+++ b/dbcrossbarlib/src/drivers/mod.rs
@@ -12,6 +12,7 @@ pub mod bigml;
 pub mod bigquery;
 pub mod bigquery_schema;
 pub mod bigquery_shared;
+pub mod bigquery_test_fixture;
 pub mod csv;
 pub mod dbcrossbar_schema;
 pub mod dbcrossbar_ts;
@@ -35,6 +36,7 @@ lazy_static! {
         driver::<bigml::BigMlLocator>(),
         driver::<bigquery::BigQueryLocator>(),
         driver::<bigquery_schema::BigQuerySchemaLocator>(),
+        driver::<bigquery_test_fixture::BigQueryTestFixtureLocator>(),
         driver::<csv::CsvLocator>(),
         driver::<dbcrossbar_schema::DbcrossbarSchemaLocator>(),
         driver::<dbcrossbar_ts::DbcrossbarTsLocator>(),

--- a/dbcrossbarlib/src/from_csv_cell.rs
+++ b/dbcrossbarlib/src/from_csv_cell.rs
@@ -153,6 +153,12 @@ impl FromCsvCell for i64 {
     }
 }
 
+impl FromCsvCell for String {
+    fn from_csv_cell(cell: &str) -> Result<Self> {
+        Ok(cell.to_owned())
+    }
+}
+
 impl FromCsvCell for serde_json::Value {
     fn from_csv_cell(cell: &str) -> Result<Self> {
         serde_json::from_str(cell)

--- a/dbcrossbarlib/src/from_json_value.rs
+++ b/dbcrossbarlib/src/from_json_value.rs
@@ -123,6 +123,15 @@ impl FromJsonValue for i64 {
     }
 }
 
+impl FromJsonValue for String {
+    fn from_json_value(json: &Value) -> Result<Self> {
+        match json {
+            Value::String(s) => Ok(s.to_owned()),
+            _ => Err(format_err!("could not parse JSON value {} as string", json)),
+        }
+    }
+}
+
 impl FromJsonValue for Value {
     fn from_json_value(json: &Value) -> Result<Self> {
         Ok(json.to_owned())

--- a/dbcrossbarlib/src/locator.rs
+++ b/dbcrossbarlib/src/locator.rs
@@ -185,6 +185,7 @@ fn locator_from_str_to_string_roundtrip() {
     let locators = vec![
         "bigquery:my_project:my_dataset.my_table",
         "bigquery-schema:dir/my_table.json",
+        "bigquery-test-fixture:my_project:my_dataset.my_table",
         "bigml:dataset",
         "bigml:datasets",
         "bigml:dataset/abc123",

--- a/guide/src/bigquery.md
+++ b/guide/src/bigquery.md
@@ -4,11 +4,10 @@ Google's [BigQuery](https://cloud.google.com/bigquery/) is a extremely scalable 
 
 When loading data into BigQuery, or extracting it, we always go via Google Cloud Storage. This is considerably faster than the load and extract functionality supplied by tools like `bq`.
 
-**COMPATIBILITY WARNING:** This driver currently relies on `gsutil` and `bq` for many tasks, but those tools are poorly-suited to the kind of automation we need. In particular, `gsutil` uses too much RAM, and `bq` sometimes print status messages on standard output instead of standard error. We plan to replace those tools with native Rust libraries at some point. This will change how the BigQuery driver handles authentication in a future version.
-
 ## Example locators
 
 - `bigquery:$PROJECT:$DATASET.$TABLE`: A BigQuery table.
+- `bigquery-test-fixture:$PROJECT:$DATASET.$TABLE`: If you only need a tiny, read-only "table" for testing purposes, you may want to try the `bigquery-test-fixture:` locator. It currently uses [`tables.insert`](https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/insert) to pass a `table.view.query` with all the table data inlined into the `VIEW` SQL. This runs about 20 times faster than `bigquery:`, at the expense of not creating a regular table. Note that the implementation details of this method may change, if we discover a faster or better way to create a small, read-only table.
 
 ## Configuration & authentication
 

--- a/guide/src/gs.md
+++ b/guide/src/gs.md
@@ -17,7 +17,7 @@ At this point, we do not support single-file output to a cloud bucket. This is r
 
 ## Configuration & authentication
 
-**0.4.x and later:** You can authenticate using either a client secret or a service key, which you can create using the [console credentials page](https://console.cloud.google.com/apis/credentials).
+You can authenticate using either a client secret or a service key, which you can create using the [console credentials page](https://console.cloud.google.com/apis/credentials).
 
 - Client secrets can be stored in `$DBCROSSBAR_CONFIG_DIR/gcloud_client_secret.json` or in `GCLOUD_CLIENT_SECRET`. These are strongly recommended for interactive use.
 - Service account keys can be stored in `$DBCROSSBAR_CONFIG_DIR/gcloud_service_account_key.json` or in `GCLOUD_SERVICE_ACCOUNT_KEY`. These are recommended for server and container use.


### PR DESCRIPTION
Creating small input tables on BigQuery for tests takes around 15-30
seconds. This is expected when working with typically large tables.

But when writing unit tests for programs that use BigQuery, we need to create
many small tables from fixture data. Paying 15-30 seconds each is
terrible.

Dave discovered a clever hack: For small read-only tables, we can load
data inline in VIEWs. This can be done in less than 0.7 seconds, which
is much nicer.

Dave and I worked together to port his Python implementation into
dbcrossbar and to extend it to handle many more types.

Limitations: We do not support STRUCT types yet.

If an input table is too big, we try to fail over to uploading using
the regular BigQuery driver.

Open questions:

- Should we materialize all views?
- Should we make the cutoff several megabytes?

TODO:

- [x] Add docs for new driver.

Co-authored-by: Dave Shirley <dave-shirley-faraday@users.noreply.github.com>
