### PR TITLE
request google drive auth scope alongside bigquery

### DIFF
--- a/dbcrossbarlib/src/clouds/gcloud/client.rs
+++ b/dbcrossbarlib/src/clouds/gcloud/client.rs
@@ -22,6 +22,7 @@ use crate::tokio_glue::IdiomaticBytesStream;
 static SCOPES: &[&str] = &[
     "https://www.googleapis.com/auth/devstorage.read_write",
     "https://www.googleapis.com/auth/bigquery",
+    "https://www.googleapis.com/auth/drive"
 ];
 
 /// An empty `GET` query.


### PR DESCRIPTION
in case people are using google drive external tables

before:

```
$ dbcrossbar cp bigquery:myproject:mydataset.mytable csv:test.csv
Error: accessDenied at 15-jLZbghg3aV5AzUgT-Yzojb0LqqKOtU6lFhoBlNTFk: Access Denied: BigQuery BigQuery: Permission denied while getting Drive credentials.
```

after:

```
$ dbcrossbar cp bigquery:myproject:mydataset.mytable csv:test.csv
[just works]
```