### PR TITLE
redshift: Try to use VARCHAR(MAX)

### DIFF
--- a/dbcrossbar/src/drivers/postgres/csv_to_binary/mod.rs
+++ b/dbcrossbar/src/drivers/postgres/csv_to_binary/mod.rs
@@ -236,6 +236,9 @@ fn json_to_binary<W: Write>(
                 _ => Err(format_err!("expected JSON string, found {}", json)),
             }
         }
+        PgScalarDataType::RedShiftVarcharMax => Err(format_err!(
+            "cannot use Redshift-specific VARCHAR(MAX) with PostgreSQL BINARY",
+        )),
         PgScalarDataType::Text => match json {
             Value::String(s) => s.as_str().write_binary(wtr),
             _ => Err(format_err!("expected JSON string, found {}", json)),
@@ -316,6 +319,9 @@ fn scalar_to_binary(
             // string. We may need to fix this someday.
             cell.write_binary(wtr)
         }
+        PgScalarDataType::RedShiftVarcharMax => Err(format_err!(
+            "cannot use Redshift-specific VARCHAR(MAX) with PostgreSQL BINARY",
+        )),
         PgScalarDataType::Text => cell.write_binary(wtr),
         PgScalarDataType::TimestampWithoutTimeZone => {
             write_cell_as_binary::<NaiveDateTime>(wtr, cell)

--- a/dbcrossbar/src/drivers/redshift/mod.rs
+++ b/dbcrossbar/src/drivers/redshift/mod.rs
@@ -192,13 +192,16 @@ impl RedshiftDriverArguments {
     /// Given a `DriverArgs` structure, convert it into Redshift credentials SQL.
     pub(crate) fn credentials_sql(&self) -> Result<String> {
         let mut out = vec![];
-        for (k, v) in &self.credentials {
+        for (idx, (k, v)) in self.credentials.iter().enumerate() {
             lazy_static! {
                 static ref KEY_RE: Regex = Regex::new("^[_A-Za-z0-9]+$")
                     .expect("invalid regex in source code");
             }
             if !KEY_RE.is_match(k) {
                 return Err(format_err!("cannot pass {:?} as Redshift credential", k));
+            }
+            if idx > 0 {
+                writeln!(&mut out, "\n")?;
             }
             writeln!(&mut out, "{} {}", k, pg_quote(v))?;
         }

--- a/dbcrossbar/tests/cli/cp/redshift.rs
+++ b/dbcrossbar/tests/cli/cp/redshift.rs
@@ -28,8 +28,12 @@ fn cp_csv_to_redshift_to_csv() {
                 return;
             }
         };
-    let iam_role =
-        env::var("REDSHIFT_TEST_IAM_ROLE").expect("Please set REDSHIFT_TEST_IAM_ROLE");
+    // let iam_role =
+    //     env::var("REDSHIFT_TEST_IAM_ROLE").expect("Please set REDSHIFT_TEST_IAM_ROLE");
+    let aws_access_key_id =
+        env::var("AWS_ACCESS_KEY_ID").expect("Please set AWS_ACCESS_KEY_ID");
+    let aws_secret_access_key =
+        env::var("AWS_SECRET_ACCESS_KEY").expect("Please set AWS_SECRET_ACCESS_KEY");
     let region =
         env::var("REDSHIFT_TEST_REGION").expect("Please set REDSHIFT_TEST_REGION");
 
@@ -43,7 +47,11 @@ fn cp_csv_to_redshift_to_csv() {
             &format!("--schema=postgres-sql:{}", schema.display()),
             // --to-arg values will be converted into Redshift "credentials"
             // arguments to COPY and UNLOAD, directly.
-            &format!("--to-arg=iam_role={}", iam_role),
+            // &format!("--to-arg=iam_role={}", iam_role),
+            &format!(
+                "--to-arg=credentials=aws_access_key_id={};aws_secret_access_key={}",
+                aws_access_key_id, aws_secret_access_key
+            ),
             &format!("--to-arg=region={}", region),
             &format!("csv:{}", src.display()),
             &redshift_table,
@@ -59,7 +67,11 @@ fn cp_csv_to_redshift_to_csv() {
             "--if-exists=overwrite",
             &format!("--temporary={}", s3_dir),
             &format!("--schema=postgres-sql:{}", schema.display()),
-            &format!("--from-arg=iam_role={}", iam_role),
+            // &format!("--from-arg=iam_role={}", iam_role),
+            &format!(
+                "--from-arg=credentials=aws_access_key_id={};aws_secret_access_key={}",
+                aws_access_key_id, aws_secret_access_key
+            ),
             &format!("--from-arg=region={}", region),
             &redshift_table,
             // Output as a single file to avoid weird naming conventions.
@@ -94,8 +106,12 @@ fn redshift_upsert() {
             return;
         }
     };
-    let iam_role =
-        env::var("REDSHIFT_TEST_IAM_ROLE").expect("Please set REDSHIFT_TEST_IAM_ROLE");
+    // let iam_role =
+    //     env::var("REDSHIFT_TEST_IAM_ROLE").expect("Please set REDSHIFT_TEST_IAM_ROLE");
+    let aws_access_key_id =
+        env::var("AWS_ACCESS_KEY_ID").expect("Please set AWS_ACCESS_KEY_ID");
+    let aws_secret_access_key =
+        env::var("AWS_SECRET_ACCESS_KEY").expect("Please set AWS_SECRET_ACCESS_KEY");
     let region =
         env::var("REDSHIFT_TEST_REGION").expect("Please set REDSHIFT_TEST_REGION");
 
@@ -119,7 +135,8 @@ fn redshift_upsert() {
                     "--to-arg=partner=dbcrossbar test v",
                     env!("CARGO_PKG_VERSION")
                 ),
-                &format!("--to-arg=iam_role={}", iam_role),
+                //&format!("--to-arg=iam_role={}", iam_role),
+                &format!("--to-arg=credentials=aws_access_key_id={};aws_secret_access_key={}", aws_access_key_id, aws_secret_access_key),
                 &format!("--to-arg=region={}", region),
                 &format!("csv:{}", src.display()),
                 &redshift_table,
@@ -135,7 +152,11 @@ fn redshift_upsert() {
             "cp",
             "--if-exists=overwrite",
             &format!("--temporary={}", s3_dir),
-            &format!("--from-arg=iam_role={}", iam_role),
+            //&format!("--from-arg=iam_role={}", iam_role),
+            &format!(
+                "--from-arg=credentials=aws_access_key_id={};aws_secret_access_key={}",
+                aws_access_key_id, aws_secret_access_key
+            ),
             &format!("--from-arg=region={}", region),
             concat!(
                 "--from-arg=partner=dbcrossbar test v",


### PR DESCRIPTION
In RedShift, TEXT is an alias for VARCHAR(255). We
want VARCHAR(MAX) instead.

But since RedShift only works because it
piggybacks off of our better-supported PostgreSQL
driver, we need to thread the VARCHAR(MAX) type
through the postgres_shared module, and error out
if it shows up in PostgreSQL-specific code.

This has not yet been tested against RedShift,
because I don't have access to an instance right
now. But once a test system is available, this
should get us close.
