### PR TITLE
add retry helper for POST requests for 503s

### DIFF
--- a/dbcrossbar/src/clouds/gcloud/bigquery/jobs.rs
+++ b/dbcrossbar/src/clouds/gcloud/bigquery/jobs.rs
@@ -10,8 +10,8 @@ use super::{
     super::{Client, NoQuery},
     BigQueryError, TableSchema,
 };
-use crate::common::*;
 use crate::drivers::bigquery_shared::TableName;
+use crate::{clouds::gcloud::Idempotency, common::*};
 
 /// Key/value pairs. See [JobConfiguration][config].
 ///
@@ -305,7 +305,7 @@ pub(crate) async fn run_job(
         project_id,
     );
     job = client
-        .post::<Job, _, _, _>(&insert_url, NoQuery, job)
+        .post::<Job, _, _, _>(&insert_url, Idempotency::UnsafeToRetry, NoQuery, job)
         .await?;
 
     // Get the URL for polling the job.

--- a/dbcrossbar/src/clouds/gcloud/client.rs
+++ b/dbcrossbar/src/clouds/gcloud/client.rs
@@ -251,7 +251,7 @@ impl Client {
                         // things we should probably retry. But this is based on
                         // guesswork not experience.
                         // In general, it is not safe to retry POST requests, however for BigQuery 503 errors, we can retry.
-                        let temporary = err.is_status() 
+                        let temporary = err.is_status()
                             && err.status() == Some(StatusCode::SERVICE_UNAVAILABLE);
                         let err: Error = err.into();
                         let err: ClientError =

--- a/dbcrossbar/src/clouds/gcloud/client.rs
+++ b/dbcrossbar/src/clouds/gcloud/client.rs
@@ -89,6 +89,14 @@ impl From<bigml::Error> for ClientError {
     }
 }
 
+/// Is it safe to retry a request? This should always be true for GET requests,
+/// but by default POST requests are not safe to retry.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum Idempotency {
+    SafeToRetry,
+    UnsafeToRetry,
+}
+
 /// A Google Cloud REST client using OAuth2.
 #[derive(Clone)]
 pub(crate) struct Client {
@@ -148,33 +156,15 @@ impl Client {
                     .headers(headers)
                     .send()
                     .await;
-                match resp_result {
-                    // The HTTP request failed outright, because of something
-                    // like a DNS error or whatever.
-                    Err(err) => {
-                        // Request and timeout errors look like the kind of
-                        // things we should probably retry. But this is based on
-                        // guesswork not experience.
-                        let temporary = err.is_request() || err.is_timeout();
-                        let err: Error = err.into();
-                        let err: ClientError =
-                            err.context(format!("could not GET {}", url)).into();
-                        if temporary {
-                            WaitStatus::FailedTemporarily(err)
-                        } else {
-                            WaitStatus::FailedPermanently(err)
-                        }
-                    }
-                    // We talked to the server and it returned a server-side
-                    // error (50-599). There's a chance that things might work
-                    // next time, we hope.
-                    Ok(resp) if resp.status().is_server_error() => {
-                        WaitStatus::FailedTemporarily(
-                            self.handle_error("GET", url, resp).await,
-                        )
-                    }
-                    Ok(resp) => WaitStatus::Finished(resp),
-                }
+                self.response_to_wait_status(
+                    "GET",
+                    url,
+                    // HTTP defines GET as idempotent, and we believe Google
+                    // follows this convention in their APIs.
+                    Idempotency::SafeToRetry,
+                    resp_result,
+                )
+                .await
             }
             .boxed()
         })
@@ -222,92 +212,19 @@ impl Client {
         }
     }
 
-    /// Make an HTTP POST request and return the response.
+    /// Make an HTTP POST request with the specified URL and body.
+    ///
     ///
     /// This may POST the request multiple times, which may cause an action to be
     /// performed multiple times. The caller is responsible for ensuring that the action
     /// is idempotent (perhaps by using `IF NOT EXISTS` for an SQL operation), and
     /// being ready to handle the case where the underlying action succeeds, but the
     /// server still returns an error.
-    async fn post_with_retry_helper<Body>(
-        &self,
-        url: &Url,
-        body: &Body,
-    ) -> Result<reqwest::Response, ClientError>
-    where
-        Body: fmt::Debug + Serialize + Sync + Send,
-    {
-        trace!("POST {}", url);
-        let token = self.token().await?;
-        let wait_options = WaitOptions::default()
-            .backoff_type(BackoffType::Exponential)
-            .retry_interval(Duration::from_secs(1))
-            // Don't retry too much because we're probably classifying some
-            // permanent errors as temporary.
-            .allowed_errors(5);
-        wait(&wait_options, move || {
-            let token = token.clone();
-            async move {
-                let resp_result = self
-                    .client
-                    .post(url.as_str())
-                    .bearer_auth(token.as_str())
-                    .json(body)
-                    .send()
-                    .await;
-                match resp_result {
-                    // The HTTP request failed outright, because of something
-                    // like a DNS error or whatever.
-                    Err(err) => {
-                        // Request and timeout errors look like the kind of
-                        // things we should probably retry. But this is based on
-                        // guesswork not experience.
-                        let temporary = err.is_request() || err.is_timeout();
-                        let err: Error = err.into();
-                        let err: ClientError =
-                            err.context(format!("could not POST {}", url)).into();
-                        if temporary {
-                            WaitStatus::FailedTemporarily(err)
-                        } else {
-                            WaitStatus::FailedPermanently(err)
-                        }
-                    }
-                    // We talked to the server and it returned a server-side
-                    // error that we expect to be transient so should retry.
-                    Ok(resp)
-                        if [
-                            StatusCode::SERVICE_UNAVAILABLE, //503
-                            StatusCode::TOO_MANY_REQUESTS,   //429
-                            StatusCode::BAD_GATEWAY,         //502
-                            StatusCode::GATEWAY_TIMEOUT,     //504
-                        ]
-                        .contains(&resp.status()) =>
-                    {
-                        WaitStatus::FailedTemporarily(
-                            self.handle_error("POST", url, resp).await,
-                        )
-                    }
-                    // We talked to the server and it returned a server-side
-                    // error (50-599). There's a chance that things might work
-                    // next time, but we're not sure so we'll just fail.
-                    Ok(resp) if resp.status().is_server_error() => {
-                        WaitStatus::FailedPermanently(
-                            self.handle_error("POST", url, resp).await,
-                        )
-                    }
-                    Ok(resp) => WaitStatus::Finished(resp),
-                }
-            }
-            .boxed()
-        })
-        .await
-    }
-
-    /// Make an HTTP POST request with the specified URL and body.
     #[instrument(level = "trace", skip(self, body))]
     pub(crate) async fn post<Output, U, Query, Body>(
         &self,
         url: U,
+        idempotency: Idempotency,
         query: Query,
         body: Body,
     ) -> Result<Output, ClientError>
@@ -320,7 +237,33 @@ impl Client {
         let url = build_url(url, query)?;
         trace!("POST {} {:?}", url, body);
         trace!("serialied {}", serde_json::to_string(&body)?);
-        let http_resp = self.post_with_retry_helper(&url, &body).await?;
+
+        let token = self.token().await?;
+        let wait_options = WaitOptions::default()
+            .backoff_type(BackoffType::Exponential)
+            .retry_interval(Duration::from_secs(1))
+            // Don't retry too much because we're probably classifying some
+            // permanent errors as temporary.
+            .allowed_errors(5);
+
+        let token_ref = &token;
+        let url_ref = &url;
+        let body_ref = &body;
+        let http_resp = wait(&wait_options, move || {
+            async move {
+                let resp_result = self
+                    .client
+                    .post(url_ref.as_str())
+                    .bearer_auth(token_ref.as_str())
+                    .json(body_ref)
+                    .send()
+                    .await;
+                self.response_to_wait_status("POST", url_ref, idempotency, resp_result)
+                    .await
+            }
+            .boxed()
+        })
+        .await?;
         self.handle_response("POST", &url, http_resp).await
     }
 
@@ -390,6 +333,81 @@ impl Client {
             .token(&self.scopes)
             .await
             .context("could not get Google Cloud OAuth2 token")
+    }
+
+    /// Is this HTTP status code something we should retry?
+    ///
+    /// Our policy for retries in a distributed system is basically "Don't retry
+    /// things you haven't seen fail in practice." This means that our caller
+    /// will get rapid feedback for configuration or user errors. It also means
+    /// that latency-to-error in complex distributed systems will be as short as
+    /// possible. And it minimized "retry amplification" where our target system
+    /// is overloaded, it fails, and we send a bunch of retries to which
+    /// overload it more. This is why we're conservative.
+    fn should_retry_status_code(&self, status_code: &StatusCode) -> bool {
+        [
+            // 503: This seems to happen pretty commonly, according to our logs.
+            StatusCode::SERVICE_UNAVAILABLE,
+            // The following are things we _might_ want to retry. But as noted
+            // above, we're waiting to see them in practice, especially because
+            // we haven't dug into either the exact HTTP semantics or the
+            // observed behavior of Google Cloud.
+            //
+            // StatusCode::TOO_MANY_REQUESTS,   //429
+            // StatusCode::BAD_GATEWAY,         //502
+            // StatusCode::GATEWAY_TIMEOUT,     //504
+        ]
+        .contains(status_code)
+    }
+
+    /// Convert an HTTP response into a [`WaitStatus`].
+    async fn response_to_wait_status(
+        &self,
+        method: &str,
+        url: &Url,
+        idempotency: Idempotency,
+        response_result: Result<reqwest::Response, reqwest::Error>,
+    ) -> WaitStatus<reqwest::Response, ClientError> {
+        match response_result {
+            // The HTTP request failed outright, because of something
+            // like a DNS error or whatever.
+            Err(err) => {
+                // Request and timeout errors look like the kind of
+                // things we should probably retry. But this is based on
+                // guesswork not experience.
+                let temporary = idempotency == Idempotency::SafeToRetry
+                    && (err.is_request() || err.is_timeout());
+                let err: Error = err.into();
+                let err: ClientError =
+                    err.context(format!("could not {} {}", method, url)).into();
+                if temporary {
+                    WaitStatus::FailedTemporarily(err)
+                } else {
+                    WaitStatus::FailedPermanently(err)
+                }
+            }
+
+            // We talked to the server and it returned a server-side
+            // error that we expect to be transient so should retry.
+            Ok(resp)
+                if idempotency == Idempotency::SafeToRetry
+                    && self.should_retry_status_code(&resp.status()) =>
+            {
+                WaitStatus::FailedTemporarily(
+                    self.handle_error(method, url, resp).await,
+                )
+            }
+
+            // We talked to the server and it returned a server-side
+            // error (50-599). There's a chance that things might work
+            // next time, but we're not sure so we'll just fail.
+            Ok(resp) if resp.status().is_server_error() => {
+                WaitStatus::FailedPermanently(
+                    self.handle_error(method, url, resp).await,
+                )
+            }
+            Ok(resp) => WaitStatus::Finished(resp),
+        }
     }
 
     /// Handle an HTTP response.

--- a/dbcrossbar/src/clouds/gcloud/client.rs
+++ b/dbcrossbar/src/clouds/gcloud/client.rs
@@ -223,9 +223,14 @@ impl Client {
     }
 
     /// Make an HTTP POST request and return the response.
-    async fn post_helper<Body>(&self, url: &Url, body: &Body) -> Result<reqwest::Response, ClientError> 
-    where 
-        Body: fmt::Debug + Serialize + std::marker::Sync,{
+    async fn post_helper<Body>(
+        &self,
+        url: &Url,
+        body: &Body,
+    ) -> Result<reqwest::Response, ClientError>
+    where
+        Body: fmt::Debug + Serialize + std::marker::Sync,
+    {
         trace!("POST {}", url);
         let token = self.token().await?;
         let wait_options = WaitOptions::default()

--- a/dbcrossbar/src/clouds/gcloud/client.rs
+++ b/dbcrossbar/src/clouds/gcloud/client.rs
@@ -273,9 +273,7 @@ impl Client {
                         }
                     }
                     // We talked to the server and it returned a server-side
-                    // 503 error.  We know that BigQuery can return 503 errors
-                    // when it is overloaded, so we can retry.
-                    // 429, 502 and 504 may also be worth retrying.
+                    // error that we expect to be transient so should retry.
                     Ok(resp)
                         if [
                             StatusCode::SERVICE_UNAVAILABLE, //503

--- a/dbcrossbar/src/clouds/gcloud/client.rs
+++ b/dbcrossbar/src/clouds/gcloud/client.rs
@@ -222,13 +222,8 @@ impl Client {
         }
     }
 
-
     /// Make an HTTP POST request and return the response.
-    async fn post_helper(
-        &self,
-        url: &Url,
-        body: Body,
-    ) -> Result<Output, ClientError> {
+    async fn post_helper(&self, url: &Url, body: Body) -> Result<Output, ClientError> {
         trace!("POST {}", url);
         let token = self.token().await?;
         let wait_options = WaitOptions::default()
@@ -256,7 +251,8 @@ impl Client {
                         // things we should probably retry. But this is based on
                         // guesswork not experience.
                         // In general, it is not safe to retry POST requests, however for BigQuery 503 errors, we can retry.
-                        let temporary = err.is_status() && err.status() == Some(StatusCode::SERVICE_UNAVAILABLE);
+                        let temporary = err.is_status() 
+                            && err.status() == Some(StatusCode::SERVICE_UNAVAILABLE);
                         let err: Error = err.into();
                         let err: ClientError =
                             err.context(format!("could not POST {}", url)).into();


### PR DESCRIPTION
Bigquery fixture uploads fail relatively frequently with 503 errors from Google, but could be safely retried.

This PR adds a retry mechanism for POST requests that fail with a 503.